### PR TITLE
feat: 대학 홍보 배너 설정

### DIFF
--- a/src/main/java/yerong/wedle/banner/controller/BannerApiController.java
+++ b/src/main/java/yerong/wedle/banner/controller/BannerApiController.java
@@ -1,0 +1,25 @@
+package yerong.wedle.banner.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import yerong.wedle.banner.dto.BannerResponse;
+import yerong.wedle.banner.service.BannerService;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/banners")
+public class BannerApiController {
+
+    private final BannerService bannerService;
+
+    @GetMapping
+    public ResponseEntity<?> getBanners() {
+        List<BannerResponse> banners = bannerService.getAllBanners();
+        return ResponseEntity.ok(banners);
+    }
+}

--- a/src/main/java/yerong/wedle/banner/domain/Banner.java
+++ b/src/main/java/yerong/wedle/banner/domain/Banner.java
@@ -1,0 +1,30 @@
+package yerong.wedle.banner.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import yerong.wedle.common.domain.BaseTimeEntity;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Banner extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "banner_id")
+    private Long bannerId;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    @Column(nullable = false)
+    private String linkUrl;
+
+    private String altText;
+
+}

--- a/src/main/java/yerong/wedle/banner/dto/BannerResponse.java
+++ b/src/main/java/yerong/wedle/banner/dto/BannerResponse.java
@@ -1,0 +1,15 @@
+package yerong.wedle.banner.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class BannerResponse {
+
+    private String imageUrl;
+    private String linkUrl;
+    private String altText;
+}

--- a/src/main/java/yerong/wedle/banner/repository/BannerRepository.java
+++ b/src/main/java/yerong/wedle/banner/repository/BannerRepository.java
@@ -1,0 +1,7 @@
+package yerong.wedle.banner.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import yerong.wedle.banner.domain.Banner;
+
+public interface BannerRepository extends JpaRepository<Banner, Long> {
+}

--- a/src/main/java/yerong/wedle/banner/service/BannerService.java
+++ b/src/main/java/yerong/wedle/banner/service/BannerService.java
@@ -1,0 +1,34 @@
+package yerong.wedle.banner.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import yerong.wedle.banner.domain.Banner;
+import yerong.wedle.banner.dto.BannerResponse;
+import yerong.wedle.banner.repository.BannerRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class BannerService {
+
+    private final BannerRepository bannerRepository;
+
+    @Transactional(readOnly = true)
+    public List<BannerResponse> getAllBanners() {
+        List<Banner> banners = bannerRepository.findAll();
+        return banners.stream()
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+    }
+
+    private BannerResponse convertToDto(Banner banner) {
+        return new BannerResponse(
+                banner.getImageUrl(),
+                banner.getLinkUrl(),
+                banner.getAltText()
+        );
+    }
+}


### PR DESCRIPTION
### PR 타입
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/university-banner` -> `develop`

### 변경 사항
- DTOs 추가:
  - BannerResponse: 배너 이미지 정보를 반환하기 위한 DTO
- Service 레이어:
  - BannerService: 배너 이미지 목록을 조회하는 로직 추가
- Repository:
  - BannerRepository: 배너 이미지 정보를 DB에서 조회하는 메서드 추가
- Controller:
  - BannerController: 배너 이미지 목록을 반환하는 API 추가

### 테스트 결과
 - 배너 API:
  - 배너 이미지 목록 조회 기능이 정상 동작함