### PR TITLE
feat: 입결 조회

### DIFF
--- a/src/main/java/yerong/wedle/entranceScore/controller/EntranceScoreController.java
+++ b/src/main/java/yerong/wedle/entranceScore/controller/EntranceScoreController.java
@@ -1,0 +1,24 @@
+package yerong.wedle.entranceScore.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import yerong.wedle.entranceScore.dto.EntranceScoreResponse;
+import yerong.wedle.entranceScore.service.EntranceScoreService;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/entrance-score-images")
+public class EntranceScoreController {
+
+    private final EntranceScoreService entranceScoreService;
+
+    @GetMapping
+    public ResponseEntity<EntranceScoreResponse> getImageByType(@RequestParam String type) {
+        EntranceScoreResponse entranceScoreResponse = entranceScoreService.getImageByType(type);
+        return ResponseEntity.ok(entranceScoreResponse);
+    }
+}

--- a/src/main/java/yerong/wedle/entranceScore/domain/EntranceScore.java
+++ b/src/main/java/yerong/wedle/entranceScore/domain/EntranceScore.java
@@ -1,0 +1,27 @@
+package yerong.wedle.entranceScore.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+public class EntranceScore {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "entrance_score_id")
+    private Long entranceScoreId;
+
+    @Column(nullable = false)
+    private String type;  // "preview" 또는 "full" 타입
+
+    @Lob
+    @Column(nullable = false)
+    private byte[] image;
+}

--- a/src/main/java/yerong/wedle/entranceScore/dto/EntranceScoreResponse.java
+++ b/src/main/java/yerong/wedle/entranceScore/dto/EntranceScoreResponse.java
@@ -1,0 +1,14 @@
+package yerong.wedle.entranceScore.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class EntranceScoreResponse {
+
+    private String type;
+    private byte[] image;
+}

--- a/src/main/java/yerong/wedle/entranceScore/repository/EntranceScoreRepository.java
+++ b/src/main/java/yerong/wedle/entranceScore/repository/EntranceScoreRepository.java
@@ -1,0 +1,10 @@
+package yerong.wedle.entranceScore.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import yerong.wedle.entranceScore.domain.EntranceScore;
+
+import java.util.Optional;
+
+public interface EntranceScoreRepository extends JpaRepository<EntranceScore, Long> {
+    Optional<EntranceScore> findByType(String type);
+}

--- a/src/main/java/yerong/wedle/entranceScore/service/EntranceScoreService.java
+++ b/src/main/java/yerong/wedle/entranceScore/service/EntranceScoreService.java
@@ -1,0 +1,25 @@
+package yerong.wedle.entranceScore.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import yerong.wedle.entranceScore.domain.EntranceScore;
+import yerong.wedle.entranceScore.dto.EntranceScoreResponse;
+import yerong.wedle.entranceScore.repository.EntranceScoreRepository;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+public class EntranceScoreService {
+
+    private final EntranceScoreRepository entranceScoreRepository;
+
+    @Transactional(readOnly = true)
+    public EntranceScoreResponse getImageByType(String type) {
+        Optional<EntranceScore> entranceScoreImage = entranceScoreRepository.findByType(type);
+        return entranceScoreImage
+                .map(image -> new EntranceScoreResponse(image.getType(), image.getImage()))
+                .orElseThrow(() -> new IllegalArgumentException("입결 이미지 정보를 찾을 수 없습니다."));
+    }
+}


### PR DESCRIPTION
### PR 타입
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/entrance-score` -> `develop`

### 변경 사항
- DTOs 추가:
  - EntranceScoreImageResponse: 미리보기용 이미지와 전체 이미지를 반환하기 위한 DTO
 
- Service 레이어:
  - EntranceScoreImageService: 미리보기용 이미지와 전체 이미지를 조회하는 로직 추가

- Repository:
  - EntranceScoreImageRepository: 이미지 정보를 DB에서 조회하는 메서드 추가

- Controller:
  - EntranceScoreImageController: 미리보기용 이미지와 전체 이미지를 반환하는 API 추가
