### PR TITLE
feat: 소셜로그인 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+/workspace.xml
+dbnavigator.xml
 
 ### STS ###
 .apt_generated
@@ -23,6 +25,7 @@ bin/
 *.iws
 *.iml
 *.ipr
+*.xml
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ build/
 !**/src/test/**/build/
 
 /workspace.xml
-dbnavigator.xml
+/dbnavigator.xml
 
 ### STS ###
 .apt_generated
@@ -45,3 +45,5 @@ out/
 
 src/main/resources/application-oauth.yml
 
+!/.idea/workspace.xml
+!/.idea/workspace.xml

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,6 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
-/workspace.xml
-/dbnavigator.xml
 
 ### STS ###
 .apt_generated
@@ -46,4 +44,4 @@ out/
 src/main/resources/application-oauth.yml
 
 !/.idea/workspace.xml
-!/.idea/workspace.xml
+!/.idea/dbnavigator.xml

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,13 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 	implementation 'org.springdoc:springdoc-openapi-starter-common:2.0.2'
 
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	implementation 'com.nimbusds:nimbus-jose-jwt:3.10'
+	implementation 'org.bouncycastle:bcpkix-jdk18on:1.72'
+	implementation group: 'org.json', name: 'json', version: '20240303'
+
 	compileOnly 'org.projectlombok:lombok'
 //	runtimeOnly 'com.mysql:mysql-connector-j'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/yerong/wedle/common/exception/CustomException.java
+++ b/src/main/java/yerong/wedle/common/exception/CustomException.java
@@ -1,0 +1,14 @@
+package yerong.wedle.common.exception;
+
+public class CustomException extends RuntimeException {
+    private final ResponseCode responseCode;
+
+    public CustomException(ResponseCode responseCode) {
+        super(responseCode.getMessage());
+        this.responseCode = responseCode;
+    }
+
+    public String getCode() {
+        return responseCode.getCode();
+    }
+}

--- a/src/main/java/yerong/wedle/common/exception/ErrorResponse.java
+++ b/src/main/java/yerong/wedle/common/exception/ErrorResponse.java
@@ -1,0 +1,12 @@
+package yerong.wedle.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+    private String code;
+    private String message;
+    private String timestamp;
+}

--- a/src/main/java/yerong/wedle/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/yerong/wedle/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,80 @@
+package yerong.wedle.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import yerong.wedle.member.exception.MemberNotFoundException;
+import yerong.wedle.member.exception.MemberDuplicateException;
+import yerong.wedle.oauth.exception.InvalidRefreshTokenException;
+import yerong.wedle.oauth.exception.OAuthProcessingException;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException customException) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                customException.getCode(),
+                customException.getMessage(),
+                LocalDateTime.now().format(formatter)
+        );
+        HttpStatus status = HttpStatus.valueOf(Integer.parseInt(customException.getCode()));
+        return ResponseEntity.status(status).body(errorResponse);
+    }
+
+    @ExceptionHandler(MemberNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleMemberNotFoundException(MemberNotFoundException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                ResponseCode.MEMBER_NOT_FOUND.getCode(),
+                ResponseCode.MEMBER_NOT_FOUND.getMessage(),
+                LocalDateTime.now().format(formatter)
+        );
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
+
+    @ExceptionHandler(MemberDuplicateException.class)
+    public ResponseEntity<ErrorResponse> handleMemberDuplicateException(MemberDuplicateException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                ResponseCode.MEMBER_DUPLICATE.getCode(),
+                ResponseCode.MEMBER_DUPLICATE.getMessage(),
+                LocalDateTime.now().format(formatter)
+        );
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
+    }
+
+    @ExceptionHandler(InvalidRefreshTokenException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidRefreshTokenException(InvalidRefreshTokenException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                ResponseCode.INVALID_REFRESH_TOKEN.getCode(),
+                ResponseCode.INVALID_REFRESH_TOKEN.getMessage(),
+                LocalDateTime.now().format(formatter)
+        );
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    @ExceptionHandler(OAuthProcessingException.class)
+    public ResponseEntity<ErrorResponse> handleOAuthProcessingException(OAuthProcessingException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                ResponseCode.OAUTH_ERROR.getCode(),
+                ResponseCode.OAUTH_ERROR.getMessage(),
+                LocalDateTime.now().format(formatter)
+        );
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception exception) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                ResponseCode.INTERNAL_SERVER_ERROR.getCode(),
+                "예상치 못한 오류가 발생했습니다.",
+                LocalDateTime.now().format(formatter)
+        );
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
+}

--- a/src/main/java/yerong/wedle/common/exception/ResponseCode.java
+++ b/src/main/java/yerong/wedle/common/exception/ResponseCode.java
@@ -1,0 +1,33 @@
+package yerong.wedle.common.exception;
+
+public enum ResponseCode {
+    INVALID_REQUEST("400", "잘못된 요청입니다."),
+    UNAUTHORIZED("401", "인증이 필요합니다."),
+    FORBIDDEN("403", "접근이 거부되었습니다."),
+    NOT_FOUND("404", "정보를 찾을 수 없습니다."),
+    INTERNAL_SERVER_ERROR("500", "서버 오류가 발생했습니다."),
+
+    // Member
+    MEMBER_NOT_FOUND("404", "회원이 존재하지 않습니다."),
+    MEMBER_DUPLICATE("409", "이미 존재하는 회원입니다."),
+
+    // OAuth
+    INVALID_REFRESH_TOKEN("400", "유효하지 않은 Refresh Token입니다."),
+    OAUTH_ERROR("500", "OAuth 처리 중 오류가 발생했습니다.");
+
+    private final String code;
+    private final String message;
+
+    ResponseCode(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/yerong/wedle/member/domain/Member.java
+++ b/src/main/java/yerong/wedle/member/domain/Member.java
@@ -1,11 +1,17 @@
 package yerong.wedle.member.domain;
 
 import jakarta.persistence.*;
+import lombok.*;
 import yerong.wedle.common.domain.BaseTimeEntity;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.*;
 
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Getter
+@Builder
 public class Member extends BaseTimeEntity {
 
     @Id
@@ -19,4 +25,6 @@ public class Member extends BaseTimeEntity {
     private String email;
     private String socialId;
 
+    @Enumerated(value = EnumType.STRING)
+    private Role role;
 }

--- a/src/main/java/yerong/wedle/member/domain/Role.java
+++ b/src/main/java/yerong/wedle/member/domain/Role.java
@@ -1,0 +1,16 @@
+package yerong.wedle.member.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@AllArgsConstructor
+public enum Role {
+
+    USER("ROLE_USER", "회원"),
+    ADMIN("ROLE_ADMIN", "관리자");
+    private String key;
+    private String title;
+}

--- a/src/main/java/yerong/wedle/member/dto/MemberRequest.java
+++ b/src/main/java/yerong/wedle/member/dto/MemberRequest.java
@@ -1,0 +1,14 @@
+package yerong.wedle.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+@Builder
+public class MemberRequest {
+    private String socialId;
+    private String username;
+    private String email;
+}

--- a/src/main/java/yerong/wedle/member/exception/MemberDuplicateException.java
+++ b/src/main/java/yerong/wedle/member/exception/MemberDuplicateException.java
@@ -1,0 +1,11 @@
+package yerong.wedle.member.exception;
+
+import yerong.wedle.common.exception.CustomException;
+import yerong.wedle.common.exception.ResponseCode;
+
+public class MemberDuplicateException extends CustomException {
+
+    public MemberDuplicateException() {
+        super(ResponseCode.MEMBER_DUPLICATE);
+    }
+}

--- a/src/main/java/yerong/wedle/member/exception/MemberNotFoundException.java
+++ b/src/main/java/yerong/wedle/member/exception/MemberNotFoundException.java
@@ -1,0 +1,11 @@
+package yerong.wedle.member.exception;
+
+import yerong.wedle.common.exception.CustomException;
+import yerong.wedle.common.exception.ResponseCode;
+
+public class MemberNotFoundException extends CustomException {
+
+    public MemberNotFoundException() {
+        super(ResponseCode.MEMBER_NOT_FOUND);
+    }
+}

--- a/src/main/java/yerong/wedle/member/repository/MemberRepository.java
+++ b/src/main/java/yerong/wedle/member/repository/MemberRepository.java
@@ -3,5 +3,9 @@ package yerong.wedle.member.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import yerong.wedle.member.domain.Member;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findBySocialId(String socialId);
 }

--- a/src/main/java/yerong/wedle/member/service/MemberService.java
+++ b/src/main/java/yerong/wedle/member/service/MemberService.java
@@ -1,4 +1,0 @@
-package yerong.wedle.member.service;
-
-public class MemberService {
-}

--- a/src/main/java/yerong/wedle/oauth/config/SecurityConfig.java
+++ b/src/main/java/yerong/wedle/oauth/config/SecurityConfig.java
@@ -1,0 +1,69 @@
+package yerong.wedle.oauth.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import yerong.wedle.oauth.handler.CustomAccessDeniedHandler;
+import yerong.wedle.oauth.jwt.CustomAuthenticationEntryPoint;
+import yerong.wedle.oauth.jwt.JwtAuthenticationFilter;
+import yerong.wedle.oauth.jwt.JwtProvider;
+
+@EnableWebSecurity
+@RequiredArgsConstructor
+@Configuration
+public class SecurityConfig {
+    private final JwtProvider jwtProvider;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+
+    @Bean
+    public SecurityFilterChain filterChain (HttpSecurity http) throws Exception{
+
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .headers(headersConfigurer ->
+                        headersConfigurer.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
+                .sessionManagement(httpSecuritySessionManagementConfigurer -> httpSecuritySessionManagementConfigurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(authorizeRequests ->
+                        authorizeRequests
+                                .requestMatchers(
+                                        AntPathRequestMatcher.antMatcher("/swagger"),
+                                        AntPathRequestMatcher.antMatcher("/swagger-ui.html"),
+                                        AntPathRequestMatcher.antMatcher("/swagger-ui/**"),
+                                        AntPathRequestMatcher.antMatcher("/swagger*/**"),
+                                        AntPathRequestMatcher.antMatcher("/api-docs"),
+                                        AntPathRequestMatcher.antMatcher("/api-docs/**"),
+                                        AntPathRequestMatcher.antMatcher("/v3/**"),
+                                        AntPathRequestMatcher.antMatcher("/v3/api-docs/**"),
+                                        AntPathRequestMatcher.antMatcher("/login/apple"),
+                                        AntPathRequestMatcher.antMatcher("/login/refresh")
+
+
+                                ).permitAll()
+                                .requestMatchers(
+                                        AntPathRequestMatcher.antMatcher(HttpMethod.OPTIONS)
+                                )
+                                .permitAll()
+                                .requestMatchers(
+                                        AntPathRequestMatcher.antMatcher("/"),
+                                        AntPathRequestMatcher.antMatcher("/api/**")
+                                ).authenticated().anyRequest().permitAll()
+                )
+                .exceptionHandling(httpSecurityExceptionHandlingConfigurer -> httpSecurityExceptionHandlingConfigurer
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                        .accessDeniedHandler(customAccessDeniedHandler)
+                )
+                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+}

--- a/src/main/java/yerong/wedle/oauth/controller/LoginController.java
+++ b/src/main/java/yerong/wedle/oauth/controller/LoginController.java
@@ -1,0 +1,64 @@
+package yerong.wedle.oauth.controller;
+
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import yerong.wedle.member.dto.MemberRequest;
+import yerong.wedle.member.exception.MemberNotFoundException;
+import yerong.wedle.oauth.dto.AccessTokenResponse;
+import yerong.wedle.oauth.dto.TokenResponse;
+import yerong.wedle.oauth.exception.InvalidRefreshTokenException;
+import yerong.wedle.oauth.service.AuthService;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class LoginController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login/apple")
+    public ResponseEntity<?> login(@RequestBody MemberRequest memberRequest) throws Exception {
+        try {
+            TokenResponse tokenResponse = authService.login(memberRequest);
+
+            HttpHeaders headers = authService.setTokenHeaders(tokenResponse);
+
+            AccessTokenResponse accessTokenResponse = AccessTokenResponse.builder()
+                    .accessToken(tokenResponse.getAccessToken())
+                    .accessTokenExpiresIn(tokenResponse.getAccessTokenExpiresIn())
+                    .build();
+            return ResponseEntity.ok().headers(headers).body(accessTokenResponse);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("로그인 중 오류가 발생했습니다.");
+        }
+
+    }
+
+    @PostMapping("/login/refresh")
+    public ResponseEntity<?> refreshAccessToken(@RequestHeader("RefreshToken") String refreshToken) {
+        try {
+            TokenResponse tokenResponse = authService.refreshAccessToken(refreshToken);
+            HttpHeaders headers = authService.setTokenHeaders(tokenResponse);
+
+            AccessTokenResponse accessTokenResponse = AccessTokenResponse.builder()
+                    .accessToken(tokenResponse.getAccessToken())
+                    .accessTokenExpiresIn(tokenResponse.getAccessTokenExpiresIn())
+                    .build();
+
+            return ResponseEntity.ok().headers(headers).body(accessTokenResponse);
+        } catch (InvalidRefreshTokenException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("유효하지 않은 Refresh Token입니다.");
+        } catch (MemberNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("회원 정보를 찾을 수 없습니다.");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("토큰 갱신 중 오류가 발생했습니다.");
+        }
+    }
+}

--- a/src/main/java/yerong/wedle/oauth/domain/RefreshToken.java
+++ b/src/main/java/yerong/wedle/oauth/domain/RefreshToken.java
@@ -1,0 +1,34 @@
+package yerong.wedle.oauth.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class RefreshToken {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "refresh_token_id", updatable = false)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false, unique = true)
+    private Long memberId;
+
+    @Column(name = "refresh_token", nullable = false)
+    private String refreshToken;
+
+    @Builder
+    public RefreshToken(Long memberId, String refreshToken){
+        this.memberId = memberId;
+        this.refreshToken = refreshToken;
+    }
+
+    public void update(String refreshToken){
+        this.refreshToken = refreshToken;
+    }
+
+}

--- a/src/main/java/yerong/wedle/oauth/dto/AccessTokenResponse.java
+++ b/src/main/java/yerong/wedle/oauth/dto/AccessTokenResponse.java
@@ -1,0 +1,13 @@
+package yerong.wedle.oauth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@AllArgsConstructor
+@Data
+public class AccessTokenResponse {
+    private String accessToken;
+    private Long accessTokenExpiresIn;
+}

--- a/src/main/java/yerong/wedle/oauth/dto/TokenResponse.java
+++ b/src/main/java/yerong/wedle/oauth/dto/TokenResponse.java
@@ -1,0 +1,15 @@
+package yerong.wedle.oauth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+@AllArgsConstructor
+public class TokenResponse {
+
+    private String accessToken;
+    private Long accessTokenExpiresIn;
+    private String refreshToken;
+}

--- a/src/main/java/yerong/wedle/oauth/exception/InvalidRefreshTokenException.java
+++ b/src/main/java/yerong/wedle/oauth/exception/InvalidRefreshTokenException.java
@@ -1,0 +1,10 @@
+package yerong.wedle.oauth.exception;
+
+import yerong.wedle.common.exception.CustomException;
+import yerong.wedle.common.exception.ResponseCode;
+
+public class InvalidRefreshTokenException extends CustomException {
+    public InvalidRefreshTokenException() {
+        super(ResponseCode.INVALID_REFRESH_TOKEN);
+    }
+}

--- a/src/main/java/yerong/wedle/oauth/exception/OAuthProcessingException.java
+++ b/src/main/java/yerong/wedle/oauth/exception/OAuthProcessingException.java
@@ -1,0 +1,11 @@
+package yerong.wedle.oauth.exception;
+
+import yerong.wedle.common.exception.CustomException;
+import yerong.wedle.common.exception.ResponseCode;
+
+public class OAuthProcessingException extends CustomException {
+
+    public OAuthProcessingException() {
+        super(ResponseCode.OAUTH_ERROR);
+    }
+}

--- a/src/main/java/yerong/wedle/oauth/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/yerong/wedle/oauth/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,23 @@
+package yerong.wedle.oauth.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException) throws IOException, ServletException {
+
+        response.sendError(HttpServletResponse.SC_FORBIDDEN); //403
+    }
+}

--- a/src/main/java/yerong/wedle/oauth/jwt/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/yerong/wedle/oauth/jwt/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,21 @@
+package yerong.wedle.oauth.jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException) throws IOException {
+
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED); //401
+    }
+}

--- a/src/main/java/yerong/wedle/oauth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/yerong/wedle/oauth/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,43 @@
+package yerong.wedle.oauth.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter  extends OncePerRequestFilter {
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String BEARER_PREFIX = "Bearer ";
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String jwt = resolveToken(request);
+
+        if (StringUtils.hasText(jwt) && jwtProvider.validateToken(jwt)) {
+            Authentication authentication = jwtProvider.getAuthentication(jwt);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/yerong/wedle/oauth/jwt/JwtProvider.java
+++ b/src/main/java/yerong/wedle/oauth/jwt/JwtProvider.java
@@ -1,0 +1,115 @@
+package yerong.wedle.oauth.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import yerong.wedle.common.exception.CustomException;
+import yerong.wedle.common.exception.ResponseCode;
+import yerong.wedle.member.domain.Role;
+import yerong.wedle.oauth.dto.TokenResponse;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+
+@Slf4j
+@Component
+public class JwtProvider {
+
+    private final Key key;
+    private static final String AUTHORITIES_KEY = "auth";
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; //access 30분
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 14; //refresh 7일
+
+    public JwtProvider(@Value("${jwt.secret_key}") String secretKey){
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public TokenResponse generateTokenDto(String socialId){
+        long now = (new Date()).getTime();
+
+        //Access Token 생성
+        Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+
+        String accessToken = Jwts.builder()
+                .setSubject(socialId)
+                .claim(AUTHORITIES_KEY, Role.USER.getKey())
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        // Refresh Token 생성
+        String refreshToken = Jwts.builder()
+                .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        return TokenResponse.builder()
+                .accessToken(accessToken)
+                .accessTokenExpiresIn(accessTokenExpiresIn.getTime())
+                .build();
+    }
+
+    public Authentication getAuthentication(String accessToken){
+        Claims claims = parseClaims(accessToken);
+
+        if(claims.get(AUTHORITIES_KEY) == null){
+            throw new CustomException(ResponseCode.UNAUTHORIZED);
+        }
+
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+        UserDetails principal = new User(claims.getSubject(), "", authorities);
+
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+
+
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.error("잘못된 JWT 서명입니다. {}", e.getMessage());
+        } catch (ExpiredJwtException e) {
+            log.error("JWT 토큰이 만료되었습니다. {}", e.getMessage());
+        } catch (UnsupportedJwtException e) {
+            log.error("지원하지 않는 JWT 토큰입니다. {}", e.getMessage());
+        } catch (IllegalArgumentException e) {
+            log.error("JWT 토큰이 잘못되었습니다. {}", e.getMessage());
+        }
+        return false;
+    }
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+}

--- a/src/main/java/yerong/wedle/oauth/repository/RefreshTokenRepository.java
+++ b/src/main/java/yerong/wedle/oauth/repository/RefreshTokenRepository.java
@@ -1,0 +1,13 @@
+package yerong.wedle.oauth.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import yerong.wedle.oauth.domain.RefreshToken;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByMemberId(Long memberId);
+    Optional<RefreshToken> findByRefreshToken(String refreshToken);
+    void deleteByMemberId(Long memberId);
+}

--- a/src/main/java/yerong/wedle/oauth/service/AuthService.java
+++ b/src/main/java/yerong/wedle/oauth/service/AuthService.java
@@ -1,0 +1,95 @@
+package yerong.wedle.oauth.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import yerong.wedle.member.domain.Member;
+import yerong.wedle.member.domain.Role;
+import yerong.wedle.member.dto.MemberRequest;
+import yerong.wedle.member.exception.MemberNotFoundException;
+import yerong.wedle.member.repository.MemberRepository;
+import yerong.wedle.oauth.domain.RefreshToken;
+import yerong.wedle.oauth.dto.TokenResponse;
+import yerong.wedle.oauth.exception.InvalidRefreshTokenException;
+import yerong.wedle.oauth.jwt.JwtProvider;
+import yerong.wedle.oauth.repository.RefreshTokenRepository;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtProvider jwtProvider;
+
+    @Transactional
+    public TokenResponse login(MemberRequest memberRequest){
+
+        Member member = memberRepository.findBySocialId(memberRequest.getSocialId()).orElse(null);
+
+        if(member == null){
+            member = Member.builder()
+                    .socialId(member.getSocialId())
+                    .email(member.getEmail())
+                    .role(Role.USER)
+                    .build();
+            memberRepository.save(member);
+        }
+
+        TokenResponse tokenResponse = jwtProvider.generateTokenDto(memberRequest.getSocialId());
+
+        Optional<RefreshToken> existingRefreshToken = refreshTokenRepository.findByMemberId(member.getMemberId());
+        if (existingRefreshToken.isPresent()) {
+            existingRefreshToken.get().update(tokenResponse.getRefreshToken());
+            refreshTokenRepository.save(existingRefreshToken.get());
+        } else {
+            RefreshToken refreshToken = RefreshToken.builder()
+                    .memberId(member.getMemberId())
+                    .refreshToken(tokenResponse.getRefreshToken())
+                    .build();
+            refreshTokenRepository.save(refreshToken);
+        }
+        return tokenResponse;
+    }
+    @Transactional
+    public TokenResponse refreshAccessToken(String refreshTokenValue){
+        // RefreshToken을 이용하여 Member 조회
+        RefreshToken refreshToken = refreshTokenRepository.findByRefreshToken(refreshTokenValue).orElse(null);
+        if (refreshToken == null) {
+            throw new InvalidRefreshTokenException();
+        }
+
+        Member member = memberRepository.findById(refreshToken.getMemberId())
+                .orElseThrow(MemberNotFoundException::new);
+
+        // 새로운 AccessToken 발급
+        TokenResponse tokenResponse = jwtProvider.generateTokenDto(member.getSocialId());
+
+        refreshToken.update(tokenResponse.getRefreshToken());
+        refreshTokenRepository.save(refreshToken);
+
+        return tokenResponse;
+    }
+
+
+    public HttpHeaders setTokenHeaders(TokenResponse tokenResponse) {
+        HttpHeaders headers = new HttpHeaders();
+        ResponseCookie cookie = ResponseCookie.from("RefreshToken", tokenResponse.getRefreshToken())
+                .path("/")
+                .maxAge(60*60*24*7) // 쿠키 유효기간 7일로 설정
+                .secure(true)
+                .sameSite("None")
+                .httpOnly(true)
+                .build();
+        headers.add("Set-cookie", cookie.toString());
+        headers.add("Authorization", tokenResponse.getAccessToken());
+
+        return headers;
+    }
+}


### PR DESCRIPTION
### PR 타입
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/social-login` -> `develop`

### 변경 사항
- 애플 로그인 API 구현:
  - `/login/apple`: 소셜 ID와 이메일로 로그인하고 액세스 토큰과 리프레시 토큰을 반환
    - **HTTP 메서드**: POST
    - 요청 본문:
      ```java
      {
        "socialId": "exampleSocialId",
        "email": "example@example.com"
      }
      ```
    - 응답 본문:
      ```java
      {
        "accessToken": "exampleAccessToken",
        "accessTokenExpiresIn": 3600
      }
      ```
  - `/login/refresh`: 리프레시 토큰으로 새로운 액세스 토큰을 발급합니다.
    - **HTTP 메서드**: POST
    - 요청 헤더:
      ```java
      {
        "accessToken": "newAccessToken",
        "accessTokenExpiresIn": 3600
      }
      ```
- 예외 처리 추가:
  - `MemberNotFoundException` 및 `InvalidRefreshTokenException`을 처리하도록 예외 처리 로직을 추가했습니다.
