### PR TITLE
feat: NEIS 학사일정 API 호출 및 데이터 반환 구현

### DIFF
--- a/src/main/java/yerong/wedle/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/yerong/wedle/common/exception/GlobalExceptionHandler.java
@@ -36,6 +36,7 @@ import yerong.wedle.oauth.exception.OAuthProcessingException;
 import yerong.wedle.post.exception.PostNotFoundException;
 import yerong.wedle.school.exception.SchoolChangeNotAllowedException;
 import yerong.wedle.school.exception.SchoolNotFoundException;
+import yerong.wedle.schoolcalendar.exception.SchoolCalendarNotFoundException;
 import yerong.wedle.star.exception.StarNotFoundException;
 import yerong.wedle.tuitionfee.exception.TuitionFeeNotFoundException;
 import yerong.wedle.university.exception.UniversityNotFoundException;
@@ -384,6 +385,16 @@ public class GlobalExceptionHandler {
         ErrorResponse errorResponse = new ErrorResponse(
                 ResponseCode.POST_LIKE_NOT_FOUND.getCode(),
                 ResponseCode.POST_LIKE_NOT_FOUND.getMessage(),
+                LocalDateTime.now().format(FORMATTER)
+        );
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
+
+    @ExceptionHandler(SchoolCalendarNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleSchoolCalendarNotFoundException(SchoolCalendarNotFoundException ex) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                ResponseCode.SCHOOL_CALENDAR_EVENT_NOT_FOUND.getCode(),
+                ResponseCode.SCHOOL_CALENDAR_EVENT_NOT_FOUND.getMessage(),
                 LocalDateTime.now().format(FORMATTER)
         );
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);

--- a/src/main/java/yerong/wedle/common/exception/ResponseCode.java
+++ b/src/main/java/yerong/wedle/common/exception/ResponseCode.java
@@ -79,8 +79,9 @@ public enum ResponseCode {
 
     //Comment
     COMMENT_NOT_FOUND("404", "해당 댓글을 찾을 수 없습니다."),
-    COMMENT_LIKE_NOT_FOUND("404", "해당 댓글 좋아요를 찾을 수 없습니다.");
+    COMMENT_LIKE_NOT_FOUND("404", "해당 댓글 좋아요를 찾을 수 없습니다."),
 
+    SCHOOL_CALENDAR_EVENT_NOT_FOUND("404", "일정을 찾을 수 없습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/yerong/wedle/meal/service/MealService.java
+++ b/src/main/java/yerong/wedle/meal/service/MealService.java
@@ -64,8 +64,8 @@ public class MealService {
     }
 
     public void initializeMealsForNewSchool(School school) {
-//        LocalDate startDate = LocalDate.now();
-        LocalDate startDate = LocalDate.of(2024, 3, 20);
+        LocalDate startDate = LocalDate.now();
+//        LocalDate startDate = LocalDate.of(2024, 3, 20);
         List<Meal> mealsToSave = new ArrayList<>();
 
         for (int i = 0; i < 14; i++) {

--- a/src/main/java/yerong/wedle/schoolcalendar/controller/SchoolCalendarApiController.java
+++ b/src/main/java/yerong/wedle/schoolcalendar/controller/SchoolCalendarApiController.java
@@ -1,0 +1,44 @@
+package yerong.wedle.schoolcalendar.controller;
+
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import yerong.wedle.schoolcalendar.dto.SchoolCalendarBetweenDatesRequest;
+import yerong.wedle.schoolcalendar.dto.SchoolCalendarByDateRequest;
+import yerong.wedle.schoolcalendar.dto.TotalSchoolCalendarResponse;
+import yerong.wedle.schoolcalendar.service.SchoolCalendarService;
+
+@Tag(name = "School Calendar API", description = "학사 일정 관련 API")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/school-calendar")
+public class SchoolCalendarApiController {
+
+    private final SchoolCalendarService schoolCalendarService;
+
+    @Operation(
+            summary = "학사 일정 조회 (단일 날짜)",
+            description = "지정한 날짜의 학사 일정을 반환합니다."
+    )
+    @GetMapping("/list/date")
+    public ResponseEntity<TotalSchoolCalendarResponse> getSchoolCalendarByDate(SchoolCalendarByDateRequest request) {
+        TotalSchoolCalendarResponse scheduleByDate = schoolCalendarService.getScheduleByDate(request);
+        return ResponseEntity.ok(scheduleByDate);
+    }
+
+    @Operation(
+            summary = "학사 일정 조회 (기간)",
+            description = "지정한 기간의 학사 일정을 반환합니다."
+    )
+    @GetMapping("/list/dates")
+    public ResponseEntity<TotalSchoolCalendarResponse> getScheduleBetween(
+            SchoolCalendarBetweenDatesRequest request) {
+        TotalSchoolCalendarResponse scheduleBetween = schoolCalendarService.getScheduleBetween(request);
+        return ResponseEntity.ok(scheduleBetween);
+    }
+}

--- a/src/main/java/yerong/wedle/schoolcalendar/domain/SchoolCalendar.java
+++ b/src/main/java/yerong/wedle/schoolcalendar/domain/SchoolCalendar.java
@@ -1,0 +1,63 @@
+package yerong.wedle.schoolcalendar.domain;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import yerong.wedle.school.domain.School;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class SchoolCalendar {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String eventName;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    private String content;
+
+    private boolean oneGradeEventYN; // 1학년 행사 여부
+    private boolean twoGradeEventYN; // 2학년 행사 여부
+    private boolean threeGradeEventYN; // 3학년 행사 여부
+    private boolean fourGradeEventYN; // 4학년 행사 여부
+    private boolean fiveGradeEventYN; // 5학년 행사 여부
+    private boolean sixGradeEventYN; // 6학년 행사 여부
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "school_id", nullable = false)
+    private School school;
+
+    @Builder
+    public SchoolCalendar(School school, String eventName, LocalDate date, String content, boolean oneGradeEventYN,
+                          boolean twoGradeEventYN, boolean threeGradeEventYN, boolean fourGradeEventYN,
+                          boolean fiveGradeEventYN, boolean sixGradeEventYN) {
+        this.school = school;
+        this.eventName = eventName;
+        this.date = date;
+        this.content = content;
+        this.oneGradeEventYN = oneGradeEventYN;
+        this.twoGradeEventYN = twoGradeEventYN;
+        this.threeGradeEventYN = threeGradeEventYN;
+        this.fourGradeEventYN = fourGradeEventYN;
+        this.fiveGradeEventYN = fiveGradeEventYN;
+        this.sixGradeEventYN = sixGradeEventYN;
+    }
+
+
+}

--- a/src/main/java/yerong/wedle/schoolcalendar/dto/EventDetailsResponse.java
+++ b/src/main/java/yerong/wedle/schoolcalendar/dto/EventDetailsResponse.java
@@ -1,0 +1,29 @@
+package yerong.wedle.schoolcalendar.dto;
+
+import lombok.Data;
+
+@Data
+public class EventDetailsResponse {
+    private String eventName;
+    private String content;
+
+    private boolean oneGradeEventYN;
+    private boolean twoGradeEventYN;
+    private boolean threeGradeEventYN;
+    private boolean fourGradeEventYN;
+    private boolean fiveGradeEventYN;
+    private boolean sixGradeEventYN;
+
+    public EventDetailsResponse(String eventName, String content, boolean oneGradeEventYN, boolean twoGradeEventYN,
+                                boolean threeGradeEventYN, boolean fourGradeEventYN,
+                                boolean fiveGradeEventYN, boolean sixGradeEventYN) {
+        this.eventName = eventName;
+        this.content = content;
+        this.oneGradeEventYN = oneGradeEventYN;
+        this.twoGradeEventYN = twoGradeEventYN;
+        this.threeGradeEventYN = threeGradeEventYN;
+        this.fourGradeEventYN = fourGradeEventYN;
+        this.fiveGradeEventYN = fiveGradeEventYN;
+        this.sixGradeEventYN = sixGradeEventYN;
+    }
+}

--- a/src/main/java/yerong/wedle/schoolcalendar/dto/SchoolCalendarBetweenDatesRequest.java
+++ b/src/main/java/yerong/wedle/schoolcalendar/dto/SchoolCalendarBetweenDatesRequest.java
@@ -1,0 +1,10 @@
+package yerong.wedle.schoolcalendar.dto;
+
+import java.time.LocalDate;
+import lombok.Data;
+
+@Data
+public class SchoolCalendarBetweenDatesRequest {
+    private LocalDate startDate;
+    private LocalDate endDate;
+}

--- a/src/main/java/yerong/wedle/schoolcalendar/dto/SchoolCalendarByDateRequest.java
+++ b/src/main/java/yerong/wedle/schoolcalendar/dto/SchoolCalendarByDateRequest.java
@@ -1,0 +1,9 @@
+package yerong.wedle.schoolcalendar.dto;
+
+import java.time.LocalDate;
+import lombok.Data;
+
+@Data
+public class SchoolCalendarByDateRequest {
+    private LocalDate date;
+}

--- a/src/main/java/yerong/wedle/schoolcalendar/dto/SchoolCalendarResponse.java
+++ b/src/main/java/yerong/wedle/schoolcalendar/dto/SchoolCalendarResponse.java
@@ -1,0 +1,16 @@
+package yerong.wedle.schoolcalendar.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class SchoolCalendarResponse {
+    private LocalDate date;
+    private List<EventDetailsResponse> events;
+
+    public SchoolCalendarResponse(LocalDate date, List<EventDetailsResponse> events) {
+        this.date = date;
+        this.events = events;
+    }
+}

--- a/src/main/java/yerong/wedle/schoolcalendar/dto/TotalSchoolCalendarResponse.java
+++ b/src/main/java/yerong/wedle/schoolcalendar/dto/TotalSchoolCalendarResponse.java
@@ -1,0 +1,17 @@
+package yerong.wedle.schoolcalendar.dto;
+
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class TotalSchoolCalendarResponse {
+    private String schoolName;
+    private boolean isEmpty;
+    private List<SchoolCalendarResponse> schoolCalendarResponses;
+
+    public TotalSchoolCalendarResponse(String schoolName, List<SchoolCalendarResponse> schoolCalendarResponses) {
+        this.schoolName = schoolName;
+        this.isEmpty = schoolCalendarResponses == null || schoolCalendarResponses.isEmpty();
+        this.schoolCalendarResponses = schoolCalendarResponses;
+    }
+}

--- a/src/main/java/yerong/wedle/schoolcalendar/exception/SchoolCalendarNotFoundException.java
+++ b/src/main/java/yerong/wedle/schoolcalendar/exception/SchoolCalendarNotFoundException.java
@@ -1,0 +1,10 @@
+package yerong.wedle.schoolcalendar.exception;
+
+import yerong.wedle.common.exception.CustomException;
+import yerong.wedle.common.exception.ResponseCode;
+
+public class SchoolCalendarNotFoundException extends CustomException {
+    public SchoolCalendarNotFoundException() {
+        super(ResponseCode.SCHOOL_CALENDAR_EVENT_NOT_FOUND);
+    }
+}

--- a/src/main/java/yerong/wedle/schoolcalendar/neis/NeisSchoolCalendarApiClient.java
+++ b/src/main/java/yerong/wedle/schoolcalendar/neis/NeisSchoolCalendarApiClient.java
@@ -1,0 +1,77 @@
+package yerong.wedle.schoolcalendar.neis;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Component
+@Slf4j
+public class NeisSchoolCalendarApiClient {
+
+    private final WebClient webClient;
+
+    @Value("${neis.key}")
+    private String API_KEY;
+
+    public NeisSchoolCalendarApiClient(WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder.baseUrl("https://open.neis.go.kr/hub/SchoolSchedule").build();
+    }
+
+
+    public List<NeisSchoolCalendarResponse> getScheduleByDate(String schoolCode, LocalDate date, String atpt) {
+        String formattedDate = date.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String url = String.format(
+                "?Type=json&pIndex=1&pSize=100&SD_SCHUL_CODE=%s&KEY=%s&ATPT_OFCDC_SC_CODE=%s&AA_YMD=%s",
+                schoolCode, API_KEY, atpt, formattedDate);
+        NeisSchoolCalendarApiResponse response = webClient.get()
+                .uri(url)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, clientResponse -> {
+                    return clientResponse.bodyToMono(String.class)
+                            .flatMap(errorBody -> {
+                                log.error("Error Response: " + errorBody);
+                                return Mono.error(new RuntimeException("API Error: " + errorBody));
+                            });
+                })
+                .bodyToMono(NeisSchoolCalendarApiResponse.class)
+                .doOnError(e -> {
+                    log.error("Error occurred: " + e.getMessage());
+                })
+                .block();
+        List<NeisSchoolCalendarResponse> neisSchoolCalendarResponse = response.getSchoolSchedule();
+        return neisSchoolCalendarResponse;
+    }
+
+    public List<NeisSchoolCalendarResponse> getScheduleBetween(String schoolCode, LocalDate startDate,
+                                                               LocalDate endDate,
+                                                               String atpt) {
+        String formattedStartDate = startDate.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String formattedEndDate = endDate.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String url = String.format(
+                "?Type=json&pIndex=1&pSize=100&SD_SCHUL_CODE=%s&KEY=%s&ATPT_OFCDC_SC_CODE=%s&AA_FROM_YMD=%s&AA_TO_YMD=%s",
+                schoolCode, API_KEY, atpt, formattedStartDate, formattedEndDate);
+        NeisSchoolCalendarApiResponse response = webClient.get()
+                .uri(url)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, clientResponse -> {
+                    return clientResponse.bodyToMono(String.class)
+                            .flatMap(errorBody -> {
+                                log.error("Error Response: " + errorBody);
+                                return Mono.error(new RuntimeException("API Error: " + errorBody));
+                            });
+                })
+                .bodyToMono(NeisSchoolCalendarApiResponse.class)
+                .doOnError(e -> {
+                    log.error("Error occurred: " + e.getMessage());
+                })
+                .block();
+        List<NeisSchoolCalendarResponse> neisSchoolCalendarResponse = response.getSchoolSchedule();
+        return neisSchoolCalendarResponse;
+    }
+}

--- a/src/main/java/yerong/wedle/schoolcalendar/neis/NeisSchoolCalendarApiResponse.java
+++ b/src/main/java/yerong/wedle/schoolcalendar/neis/NeisSchoolCalendarApiResponse.java
@@ -1,0 +1,30 @@
+package yerong.wedle.schoolcalendar.neis;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Collections;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class NeisSchoolCalendarApiResponse {
+
+    @JsonProperty("SchoolSchedule")
+    private List<SchoolCalendarInfo> schoolSchedule;
+
+    public List<NeisSchoolCalendarResponse> getSchoolSchedule() {
+        if (schoolSchedule != null && !schoolSchedule.isEmpty()) {
+            for (SchoolCalendarInfo info : schoolSchedule) {
+                if (info.getHead() != null && !info.getHead().isEmpty()) {
+                    SchoolCalendarResult result = info.getHead().get(0).getSchoolResult();
+                    if (result != null && "INFO-200".equals(result.getCode())) {
+                        return Collections.emptyList();
+                    }
+                }
+                if (info.getRow() != null) {
+                    return info.getRow();
+                }
+            }
+        }
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/yerong/wedle/schoolcalendar/neis/NeisSchoolCalendarResponse.java
+++ b/src/main/java/yerong/wedle/schoolcalendar/neis/NeisSchoolCalendarResponse.java
@@ -1,0 +1,40 @@
+package yerong.wedle.schoolcalendar.neis;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import lombok.Getter;
+
+@Getter
+public class NeisSchoolCalendarResponse {
+    @JsonProperty("EVENT_NM")
+    private String eventName;  // 학교 이름
+
+    @JsonProperty("AA_YMD")
+    private String date; //학사 일자
+
+    public LocalDate getParsedDate() {
+        return LocalDate.parse(date, DateTimeFormatter.ofPattern("yyyyMMdd")); // LocalDate로 변환
+    }
+
+    @JsonProperty("EVENT_CNTNT")
+    private String content;  // 행사 내용
+
+    @JsonProperty("ONE_GRADE_EVENT_YN")
+    private String oneGradeEventYN; // 1학년 행사 여부
+
+    @JsonProperty("TW_GRADE_EVENT_YN")
+    private String twoGradeEventYN; // 2학년 행사 여부
+
+    @JsonProperty("THREE_GRADE_EVENT_YN")
+    private String threeGradeEventYN; // 3학년 행사 여부
+
+    @JsonProperty("FR_GRADE_EVENT_YN")
+    private String fourGradeEventYN; // 4학년 행사 여부
+
+    @JsonProperty("FIV_GRADE_EVENT_YN")
+    private String fiveGradeEventYN; // 5학년 행사 여부
+
+    @JsonProperty("SIX_GRADE_EVENT_YN")
+    private String sixGradeEventYN; // 6학년 행사 여부
+}

--- a/src/main/java/yerong/wedle/schoolcalendar/neis/SchoolCalendarHead.java
+++ b/src/main/java/yerong/wedle/schoolcalendar/neis/SchoolCalendarHead.java
@@ -1,0 +1,12 @@
+package yerong.wedle.schoolcalendar.neis;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class SchoolCalendarHead {
+    @JsonProperty("list_total_count")
+    private int listTotalCount;
+    @JsonProperty("RESULT")
+    private SchoolCalendarResult schoolResult;
+}

--- a/src/main/java/yerong/wedle/schoolcalendar/neis/SchoolCalendarInfo.java
+++ b/src/main/java/yerong/wedle/schoolcalendar/neis/SchoolCalendarInfo.java
@@ -1,0 +1,14 @@
+package yerong.wedle.schoolcalendar.neis;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class SchoolCalendarInfo {
+    @JsonProperty("head")
+    private List<SchoolCalendarHead> head;
+
+    @JsonProperty("row")
+    private List<NeisSchoolCalendarResponse> row;
+}

--- a/src/main/java/yerong/wedle/schoolcalendar/neis/SchoolCalendarResult.java
+++ b/src/main/java/yerong/wedle/schoolcalendar/neis/SchoolCalendarResult.java
@@ -1,0 +1,12 @@
+package yerong.wedle.schoolcalendar.neis;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class SchoolCalendarResult {
+    @JsonProperty("CODE")
+    private String code;
+    @JsonProperty("MESSAGE")
+    private String msg;
+}

--- a/src/main/java/yerong/wedle/schoolcalendar/repository/SchoolCalendarRepository.java
+++ b/src/main/java/yerong/wedle/schoolcalendar/repository/SchoolCalendarRepository.java
@@ -1,0 +1,11 @@
+package yerong.wedle.schoolcalendar.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import yerong.wedle.school.domain.School;
+import yerong.wedle.schoolcalendar.domain.SchoolCalendar;
+
+public interface SchoolCalendarRepository extends JpaRepository<SchoolCalendar, Long> {
+    List<SchoolCalendar> findBySchoolAndDateBetween(School school, LocalDate startDate, LocalDate endDate);
+}

--- a/src/main/java/yerong/wedle/schoolcalendar/service/SchoolCalendarService.java
+++ b/src/main/java/yerong/wedle/schoolcalendar/service/SchoolCalendarService.java
@@ -1,0 +1,174 @@
+package yerong.wedle.schoolcalendar.service;
+
+import jakarta.transaction.Transactional;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import yerong.wedle.member.domain.Member;
+import yerong.wedle.member.exception.MemberNotFoundException;
+import yerong.wedle.member.repository.MemberRepository;
+import yerong.wedle.school.domain.School;
+import yerong.wedle.school.repository.SchoolRepository;
+import yerong.wedle.schoolcalendar.domain.SchoolCalendar;
+import yerong.wedle.schoolcalendar.dto.EventDetailsResponse;
+import yerong.wedle.schoolcalendar.dto.SchoolCalendarBetweenDatesRequest;
+import yerong.wedle.schoolcalendar.dto.SchoolCalendarByDateRequest;
+import yerong.wedle.schoolcalendar.dto.SchoolCalendarResponse;
+import yerong.wedle.schoolcalendar.dto.TotalSchoolCalendarResponse;
+import yerong.wedle.schoolcalendar.neis.NeisSchoolCalendarApiClient;
+import yerong.wedle.schoolcalendar.neis.NeisSchoolCalendarResponse;
+import yerong.wedle.schoolcalendar.repository.SchoolCalendarRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SchoolCalendarService {
+    private final SchoolCalendarRepository schoolCalendarRepository;
+    private final NeisSchoolCalendarApiClient neisSchoolCalendarApiClient;
+    private final MemberRepository memberRepository;
+    private final SchoolRepository schoolRepository;
+
+    public TotalSchoolCalendarResponse getScheduleByDate(SchoolCalendarByDateRequest request) {
+        String socialId = getCurrentUserId();
+        Member member = memberRepository.findBySocialId(socialId)
+                .orElseThrow(MemberNotFoundException::new);
+        School school = member.getSchool();
+        List<NeisSchoolCalendarResponse> scheduleByDate = neisSchoolCalendarApiClient.getScheduleByDate(
+                school.getSchoolCode(), request.getDate(), school.getAtptCode());
+        return convertToSchoolCalendarResponse(scheduleByDate, school.getName());
+    }
+
+    public TotalSchoolCalendarResponse getScheduleBetween(SchoolCalendarBetweenDatesRequest request) {
+        String socialId = getCurrentUserId();
+        Member member = memberRepository.findBySocialId(socialId)
+                .orElseThrow(MemberNotFoundException::new);
+        School school = member.getSchool();
+
+        List<NeisSchoolCalendarResponse> scheduleByDate = neisSchoolCalendarApiClient.getScheduleBetween(
+                school.getSchoolCode(), request.getStartDate(), request.getEndDate(), school.getAtptCode());
+        return convertToSchoolCalendarResponse(scheduleByDate, school.getName());
+    }
+
+    private TotalSchoolCalendarResponse convertToSchoolCalendarResponse(
+            List<NeisSchoolCalendarResponse> neisSchoolCalendarResponses, String schoolName) {
+
+        Map<LocalDate, List<EventDetailsResponse>> groupedEvents = neisSchoolCalendarResponses.stream()
+                .collect(Collectors.groupingBy(
+                        response -> response.getParsedDate(),
+                        Collectors.mapping(response -> new EventDetailsResponse(
+                                response.getEventName(),
+                                response.getContent(),
+                                "Y".equals(response.getOneGradeEventYN()),
+                                "Y".equals(response.getTwoGradeEventYN()),
+                                "Y".equals(response.getThreeGradeEventYN()),
+                                "Y".equals(response.getFourGradeEventYN()),
+                                "Y".equals(response.getFiveGradeEventYN()),
+                                "Y".equals(response.getSixGradeEventYN())
+                        ), Collectors.toList())
+                ));
+        if (groupedEvents.isEmpty()) {
+            return new TotalSchoolCalendarResponse(schoolName, null);
+        }
+        List<SchoolCalendarResponse> schoolCalendarResponses = groupedEvents.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(entry -> new SchoolCalendarResponse(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toList());
+        return new TotalSchoolCalendarResponse(schoolName, schoolCalendarResponses);
+    }
+
+    private String getCurrentUserId() {
+        String socialId = SecurityContextHolder.getContext().getAuthentication().getName();
+
+        return socialId;
+    }
+
+    public void initializeSchoolCalendar(School school) {
+        LocalDate now = LocalDate.now();
+        LocalDate currentMonth = now.withDayOfMonth(1);
+        LocalDate previousMonth = currentMonth.minusMonths(1);
+        LocalDate nextMonth = currentMonth.plusMonths(1);
+
+        saveCurrentAndNextMonthSchoolCalendar(school, previousMonth, currentMonth, nextMonth);
+    }
+
+    @Scheduled(cron = "0 0 0 1 * ?")
+    public void manageSchoolCalendars() {
+        List<School> schools = schoolRepository.findAll();
+        for (School school : schools) {
+            manageCalendars(school);
+        }
+    }
+
+    private void saveCurrentAndNextMonthSchoolCalendar(School school, LocalDate previousMonth, LocalDate currentMonth,
+                                                       LocalDate nextMonth) {
+
+        List<NeisSchoolCalendarResponse> previousMonthSchedules = neisSchoolCalendarApiClient.getScheduleBetween(
+                school.getSchoolCode(), previousMonth, previousMonth.plusMonths(1).minusDays(1), school.getAtptCode());
+
+        TotalSchoolCalendarResponse previousTotalSchoolCalendarResponse = convertToSchoolCalendarResponse(
+                previousMonthSchedules, school.getName());
+        saveOrUpdateSchoolCalendars(school, previousTotalSchoolCalendarResponse);
+
+        List<NeisSchoolCalendarResponse> currentMonthSchedules = neisSchoolCalendarApiClient.getScheduleBetween(
+                school.getSchoolCode(), currentMonth, currentMonth.plusMonths(1).minusDays(1), school.getAtptCode());
+
+        TotalSchoolCalendarResponse currentTotalSchoolCalendarResponse = convertToSchoolCalendarResponse(
+                currentMonthSchedules, school.getName());
+        saveOrUpdateSchoolCalendars(school, currentTotalSchoolCalendarResponse);
+
+        List<NeisSchoolCalendarResponse> nextMonthSchedules = neisSchoolCalendarApiClient.getScheduleBetween(
+                school.getSchoolCode(), nextMonth, nextMonth.plusMonths(1).minusDays(1), school.getAtptCode());
+        TotalSchoolCalendarResponse nextTotalSchoolCalendarResponse = convertToSchoolCalendarResponse(
+                nextMonthSchedules, school.getName());
+        saveOrUpdateSchoolCalendars(school, nextTotalSchoolCalendarResponse);
+    }
+
+    private void manageCalendars(School school) {
+        LocalDate now = LocalDate.now();
+        LocalDate previousMonth = now.minusMonths(2);
+        LocalDate currentMonth = now.withDayOfMonth(1);
+        LocalDate nextMonth = currentMonth.plusMonths(1);
+
+        deletePreviousMonthCalendars(previousMonth, school);
+
+        List<NeisSchoolCalendarResponse> nextMonthSchedules = neisSchoolCalendarApiClient.getScheduleBetween(
+                school.getSchoolCode(), nextMonth, nextMonth.plusMonths(1).minusDays(1), school.getAtptCode());
+        TotalSchoolCalendarResponse nextTotalSchoolCalendarResponse = convertToSchoolCalendarResponse(
+                nextMonthSchedules,
+                school.getName());
+        saveOrUpdateSchoolCalendars(school, nextTotalSchoolCalendarResponse);
+    }
+
+    private void deletePreviousMonthCalendars(LocalDate previousMonth, School school) {
+        List<SchoolCalendar> previousMonthCalendars = schoolCalendarRepository.findBySchoolAndDateBetween(school,
+                previousMonth.withDayOfMonth(1), previousMonth.withDayOfMonth(previousMonth.lengthOfMonth()));
+
+        schoolCalendarRepository.deleteAll(previousMonthCalendars);
+    }
+
+    private void saveOrUpdateSchoolCalendars(School school, TotalSchoolCalendarResponse calendarResponses) {
+
+        for (SchoolCalendarResponse response : calendarResponses.getSchoolCalendarResponses()) {
+            for (EventDetailsResponse event : response.getEvents()) {
+                SchoolCalendar schoolCalendar = SchoolCalendar.builder()
+                        .school(school)
+                        .content(event.getContent())
+                        .date(response.getDate())
+                        .oneGradeEventYN(event.isOneGradeEventYN())
+                        .twoGradeEventYN(event.isTwoGradeEventYN())
+                        .threeGradeEventYN(event.isThreeGradeEventYN())
+                        .fourGradeEventYN(event.isFourGradeEventYN())
+                        .fiveGradeEventYN(event.isFiveGradeEventYN())
+                        .sixGradeEventYN(event.isSixGradeEventYN())
+                        .eventName(event.getEventName()).build();
+                schoolCalendarRepository.save(schoolCalendar);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
### PR 타입
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/school-calendar` -> `develop`

### 변경 사항:
- NEIS 학사일정 API 호출 기능 추가:
  - NEIS 학사일정 API를 호출하여 학교별 학사일정을 날짜별로 가져오는 기능을 구현.
  - 날짜별 학사일정을 LocalDate 기준으로 그룹화하여 SchoolCalendarResponse에 반환.
- 일정 데이터 반환 로직 수정:
  - 일정이 없을 경우, 빈 리스트를 반환하는 방식으로 처리.
  - 일정이 존재할 경우, 날짜별로 정렬된 학사일정 데이터를 반환.
- TotalSchoolCalendarResponse 구조 수정:
  - 학사일정이 존재하는지 여부를 나타내는 isEmpty 필드를 추가하여, 클라이언트에서 학사일정 여부를 쉽게 확인할 수 있도록 함.
- 주기적인 학사일정 초기화:
  - 매월 1일, 이전 달 및 다음 달의 학사일정을 자동으로 관리하는 주기적인 작업을 스케줄링.
  - 학사일정 초기화 및 저장 로직 구현.

### 추가 설명:
- 주기적인 학사일정 관리: 매월 1일에 자동으로 이전 달 및 다음 달의 학사일정을 관리하는 스케줄링을 추가하여, 학사일정이 자동으로 업데이트되도록 설정하였습니다.
