### PR TITLE
feat: 회원별 TodoList 생성 및 관리 기능 구현

### DIFF
--- a/src/main/java/yerong/wedle/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/yerong/wedle/common/exception/GlobalExceptionHandler.java
@@ -38,6 +38,7 @@ import yerong.wedle.school.exception.SchoolChangeNotAllowedException;
 import yerong.wedle.school.exception.SchoolNotFoundException;
 import yerong.wedle.schoolcalendar.exception.SchoolCalendarNotFoundException;
 import yerong.wedle.star.exception.StarNotFoundException;
+import yerong.wedle.todo.exception.TodoNotFoundException;
 import yerong.wedle.tuitionfee.exception.TuitionFeeNotFoundException;
 import yerong.wedle.university.exception.UniversityNotFoundException;
 
@@ -395,6 +396,16 @@ public class GlobalExceptionHandler {
         ErrorResponse errorResponse = new ErrorResponse(
                 ResponseCode.SCHOOL_CALENDAR_EVENT_NOT_FOUND.getCode(),
                 ResponseCode.SCHOOL_CALENDAR_EVENT_NOT_FOUND.getMessage(),
+                LocalDateTime.now().format(FORMATTER)
+        );
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
+
+    @ExceptionHandler(TodoNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleTodoNotFoundException(TodoNotFoundException ex) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                ResponseCode.TODO_NOT_FOUND.getCode(),
+                ResponseCode.TODO_NOT_FOUND.getMessage(),
                 LocalDateTime.now().format(FORMATTER)
         );
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);

--- a/src/main/java/yerong/wedle/common/exception/ResponseCode.java
+++ b/src/main/java/yerong/wedle/common/exception/ResponseCode.java
@@ -81,7 +81,8 @@ public enum ResponseCode {
     COMMENT_NOT_FOUND("404", "해당 댓글을 찾을 수 없습니다."),
     COMMENT_LIKE_NOT_FOUND("404", "해당 댓글 좋아요를 찾을 수 없습니다."),
 
-    SCHOOL_CALENDAR_EVENT_NOT_FOUND("404", "일정을 찾을 수 없습니다.");
+    SCHOOL_CALENDAR_EVENT_NOT_FOUND("404", "일정을 찾을 수 없습니다."),
+    TODO_NOT_FOUND("404", "할일을 찾을 수 없습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/yerong/wedle/member/domain/Member.java
+++ b/src/main/java/yerong/wedle/member/domain/Member.java
@@ -23,6 +23,7 @@ import lombok.NoArgsConstructor;
 import yerong.wedle.common.domain.BaseTimeEntity;
 import yerong.wedle.notification.domain.Notification;
 import yerong.wedle.school.domain.School;
+import yerong.wedle.todo.domain.TodoList;
 
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -61,6 +62,9 @@ public class Member extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY) // Member와 Notification 간의 관계 설정
     private List<Notification> notifications;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY)  // Member와 TodoList 간의 관계 설정
+    private List<TodoList> todoLists;
 
     public void setExistingMember(boolean isExistingMember) {
         this.isExistingMember = isExistingMember;

--- a/src/main/java/yerong/wedle/todo/controller/TodoApiController.java
+++ b/src/main/java/yerong/wedle/todo/controller/TodoApiController.java
@@ -1,0 +1,83 @@
+package yerong.wedle.todo.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import yerong.wedle.todo.dto.TodoRequest;
+import yerong.wedle.todo.dto.TodoResponse;
+import yerong.wedle.todo.dto.UpdateTodoCompletionRequest;
+import yerong.wedle.todo.dto.UpdateTodoDateRequest;
+import yerong.wedle.todo.dto.UpdateTodoTaskRequest;
+import yerong.wedle.todo.service.TodoService;
+
+@Tag(name = "To Do List API", description = "To Do List API")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/todo-list")
+public class TodoApiController {
+    private final TodoService todoService;
+
+    @Operation(
+            summary = "할일 추가",
+            description = "할일을 추가합니다"
+    )
+    @PostMapping("/todo")
+    public ResponseEntity<TodoResponse> addTodo(@RequestBody TodoRequest todoRequest) {
+        System.out.println("name = " + todoRequest.getTask());
+        System.out.println("date = " + todoRequest.getDate());
+        TodoResponse todoResponse = todoService.addTodo(todoRequest);
+        return ResponseEntity.ok(todoResponse);
+    }
+
+    @Operation(
+            summary = "할일 이름 수정",
+            description = "할일의 이름을 수정합니다"
+    )
+    @PutMapping("/todo/update-task")
+    public ResponseEntity<TodoResponse> updateTodoTask(@RequestBody UpdateTodoTaskRequest todoRenameRequest) {
+        TodoResponse todoResponse = todoService.updateTodoTask(todoRenameRequest);
+        return ResponseEntity.ok(todoResponse);
+    }
+
+    @Operation(
+            summary = "할일 날짜 수정",
+            description = "할일 날짜를 수정합니다"
+    )
+    @PutMapping("/todo/update-date")
+    public ResponseEntity<TodoResponse> updateTodoDate(@RequestBody UpdateTodoDateRequest updateTodoDateRequest) {
+        TodoResponse todoResponse = todoService.updateTodoDate(updateTodoDateRequest);
+        return ResponseEntity.ok(todoResponse);
+    }
+
+    @Operation(
+            summary = "할일 성공 여부 수정",
+            description = "할일 성공 여부를 수정합니다"
+    )
+    @PutMapping("/todo/completion")
+    public ResponseEntity<TodoResponse> updateTodoCompletion(
+            @RequestBody UpdateTodoCompletionRequest updateTodoCompletionRequest) {
+        TodoResponse todoResponse = todoService.updateTodoCompletion(updateTodoCompletionRequest);
+        return ResponseEntity.ok(todoResponse);
+    }
+
+    @Operation(summary = "할일 삭제", description = "할일을 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "할일이 성공적으로 삭제되었습니다."),
+            @ApiResponse(responseCode = "404", description = "할일을 찾을 수 없음")
+    })
+    @DeleteMapping("/todd/{todoId}")
+    public ResponseEntity<String> updateTodoCompletion(@PathVariable Long todoId) {
+        todoService.deleteTodo(todoId);
+        return ResponseEntity.ok("Todo가 성공적으로 삭제되었습니다.");
+    }
+}

--- a/src/main/java/yerong/wedle/todo/controller/TodoApiController.java
+++ b/src/main/java/yerong/wedle/todo/controller/TodoApiController.java
@@ -4,15 +4,18 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import yerong.wedle.todo.dto.TodoListResponse;
 import yerong.wedle.todo.dto.TodoRequest;
 import yerong.wedle.todo.dto.TodoResponse;
 import yerong.wedle.todo.dto.UpdateTodoCompletionRequest;
@@ -79,5 +82,19 @@ public class TodoApiController {
     public ResponseEntity<String> updateTodoCompletion(@PathVariable Long todoId) {
         todoService.deleteTodo(todoId);
         return ResponseEntity.ok("Todo가 성공적으로 삭제되었습니다.");
+    }
+
+    @Operation(
+            summary = "특정 날짜의 할일 목록 조회",
+            description = "특정 날짜에 해당하는 할일 목록을 조회합니다"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "할일 목록이 성공적으로 반환되었습니다."),
+            @ApiResponse(responseCode = "404", description = "할일을 찾을 수 없음")
+    })
+    @GetMapping("/todos/{date}")
+    public ResponseEntity<TodoListResponse> getTodosByDate(@PathVariable LocalDate date) {
+        TodoListResponse todoResponses = todoService.getTodosByDate(date);
+        return ResponseEntity.ok(todoResponses);
     }
 }

--- a/src/main/java/yerong/wedle/todo/domain/Todo.java
+++ b/src/main/java/yerong/wedle/todo/domain/Todo.java
@@ -1,0 +1,66 @@
+package yerong.wedle.todo.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import yerong.wedle.common.domain.BaseTimeEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Todo extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Column(nullable = false)
+    private String task;
+
+    @Column(nullable = false)
+    private boolean isCompleted = false;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "todo_list_id")
+    private TodoList todoList;
+
+    public Todo(LocalDate date, String task, TodoList todoList) {
+        this.date = date;
+        this.task = task;
+        this.isCompleted = false;
+        this.todoList = todoList;
+    }
+
+    public void addTodoList(TodoList todoList) {
+        this.todoList = todoList;
+    }
+
+    public void markAsCompleted() {
+        this.isCompleted = true;
+    }
+
+    public void updateTask(String task) {
+        this.task = task;
+    }
+
+    public void updateDate(LocalDate date) {
+        this.date = date;
+    }
+
+    public void updateCompleted(boolean isCompleted) {
+        this.isCompleted = isCompleted;
+    }
+
+}

--- a/src/main/java/yerong/wedle/todo/domain/TodoList.java
+++ b/src/main/java/yerong/wedle/todo/domain/TodoList.java
@@ -1,0 +1,48 @@
+package yerong.wedle.todo.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import yerong.wedle.common.domain.BaseTimeEntity;
+import yerong.wedle.member.domain.Member;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TodoList extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToMany(mappedBy = "todoList", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Todo> todos = new ArrayList<>();
+
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    public TodoList(Member member) {
+        this.member = member;
+    }
+
+    public boolean isAllTasksCompleted() {
+        return todos.stream().allMatch(Todo::isCompleted);
+    }
+
+    public void addTask(Todo todo) {
+        todo.addTodoList(this);
+        this.todos.add(todo);
+    }
+}

--- a/src/main/java/yerong/wedle/todo/dto/DeleteTodoRequest.java
+++ b/src/main/java/yerong/wedle/todo/dto/DeleteTodoRequest.java
@@ -1,0 +1,8 @@
+package yerong.wedle.todo.dto;
+
+import lombok.Getter;
+
+@Getter
+public class DeleteTodoRequest {
+    private Long todoId;
+}

--- a/src/main/java/yerong/wedle/todo/dto/ToDoDateRequest.java
+++ b/src/main/java/yerong/wedle/todo/dto/ToDoDateRequest.java
@@ -1,0 +1,9 @@
+package yerong.wedle.todo.dto;
+
+import java.time.LocalDate;
+import lombok.Data;
+
+@Data
+public class ToDoDateRequest {
+    private LocalDate date;
+}

--- a/src/main/java/yerong/wedle/todo/dto/TodoListResponse.java
+++ b/src/main/java/yerong/wedle/todo/dto/TodoListResponse.java
@@ -1,0 +1,16 @@
+package yerong.wedle.todo.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class TodoListResponse {
+    private LocalDate date;
+    private List<TodoResponse> todoResponses;
+
+    public TodoListResponse(LocalDate date, List<TodoResponse> responses) {
+        this.date = date;
+        todoResponses = responses;
+    }
+}

--- a/src/main/java/yerong/wedle/todo/dto/TodoRequest.java
+++ b/src/main/java/yerong/wedle/todo/dto/TodoRequest.java
@@ -1,0 +1,10 @@
+package yerong.wedle.todo.dto;
+
+import java.time.LocalDate;
+import lombok.Getter;
+
+@Getter
+public class TodoRequest {
+    private String task;
+    private LocalDate date;
+}

--- a/src/main/java/yerong/wedle/todo/dto/TodoResponse.java
+++ b/src/main/java/yerong/wedle/todo/dto/TodoResponse.java
@@ -1,0 +1,17 @@
+package yerong.wedle.todo.dto;
+
+import java.time.LocalDate;
+import lombok.Data;
+
+@Data
+public class TodoResponse {
+    String task;
+    private LocalDate date;
+    private boolean completed;
+
+    public TodoResponse(LocalDate date, String task, boolean completed) {
+        this.date = date;
+        this.task = task;
+        this.completed = completed;
+    }
+}

--- a/src/main/java/yerong/wedle/todo/dto/UpdateTodoCompletionRequest.java
+++ b/src/main/java/yerong/wedle/todo/dto/UpdateTodoCompletionRequest.java
@@ -1,0 +1,9 @@
+package yerong.wedle.todo.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateTodoCompletionRequest {
+    private Long todoId;
+    private boolean completed;
+}

--- a/src/main/java/yerong/wedle/todo/dto/UpdateTodoDateRequest.java
+++ b/src/main/java/yerong/wedle/todo/dto/UpdateTodoDateRequest.java
@@ -1,0 +1,10 @@
+package yerong.wedle.todo.dto;
+
+import java.time.LocalDate;
+import lombok.Getter;
+
+@Getter
+public class UpdateTodoDateRequest {
+    private Long todoId;
+    private LocalDate date;
+}

--- a/src/main/java/yerong/wedle/todo/dto/UpdateTodoTaskRequest.java
+++ b/src/main/java/yerong/wedle/todo/dto/UpdateTodoTaskRequest.java
@@ -1,0 +1,9 @@
+package yerong.wedle.todo.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateTodoTaskRequest {
+    Long todoId;
+    String task;
+}

--- a/src/main/java/yerong/wedle/todo/exception/TodoNotFoundException.java
+++ b/src/main/java/yerong/wedle/todo/exception/TodoNotFoundException.java
@@ -1,0 +1,10 @@
+package yerong.wedle.todo.exception;
+
+import yerong.wedle.common.exception.CustomException;
+import yerong.wedle.common.exception.ResponseCode;
+
+public class TodoNotFoundException extends CustomException {
+    public TodoNotFoundException() {
+        super(ResponseCode.TODO_NOT_FOUND);
+    }
+}

--- a/src/main/java/yerong/wedle/todo/repository/TodoListRepository.java
+++ b/src/main/java/yerong/wedle/todo/repository/TodoListRepository.java
@@ -1,0 +1,10 @@
+package yerong.wedle.todo.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import yerong.wedle.member.domain.Member;
+import yerong.wedle.todo.domain.TodoList;
+
+public interface TodoListRepository extends JpaRepository<TodoList, Long> {
+    Optional<TodoList> findByMember(Member member);
+}

--- a/src/main/java/yerong/wedle/todo/repository/TodoRepository.java
+++ b/src/main/java/yerong/wedle/todo/repository/TodoRepository.java
@@ -1,0 +1,7 @@
+package yerong.wedle.todo.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import yerong.wedle.todo.domain.Todo;
+
+public interface TodoRepository extends JpaRepository<Todo, Long> {
+}

--- a/src/main/java/yerong/wedle/todo/repository/TodoRepository.java
+++ b/src/main/java/yerong/wedle/todo/repository/TodoRepository.java
@@ -1,7 +1,11 @@
 package yerong.wedle.todo.repository;
 
+import java.time.LocalDate;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import yerong.wedle.todo.domain.Todo;
+import yerong.wedle.todo.domain.TodoList;
 
 public interface TodoRepository extends JpaRepository<Todo, Long> {
+    List<Todo> findByTodoListAndDate(TodoList todoList, LocalDate date);
 }

--- a/src/main/java/yerong/wedle/todo/service/TodoService.java
+++ b/src/main/java/yerong/wedle/todo/service/TodoService.java
@@ -1,0 +1,109 @@
+package yerong.wedle.todo.service;
+
+import jakarta.transaction.Transactional;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import yerong.wedle.member.domain.Member;
+import yerong.wedle.member.exception.MemberNotFoundException;
+import yerong.wedle.member.exception.UnauthorizedAccessException;
+import yerong.wedle.member.repository.MemberRepository;
+import yerong.wedle.todo.domain.Todo;
+import yerong.wedle.todo.domain.TodoList;
+import yerong.wedle.todo.dto.TodoRequest;
+import yerong.wedle.todo.dto.TodoResponse;
+import yerong.wedle.todo.dto.UpdateTodoCompletionRequest;
+import yerong.wedle.todo.dto.UpdateTodoDateRequest;
+import yerong.wedle.todo.dto.UpdateTodoTaskRequest;
+import yerong.wedle.todo.exception.TodoNotFoundException;
+import yerong.wedle.todo.repository.TodoListRepository;
+import yerong.wedle.todo.repository.TodoRepository;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class TodoService {
+    private final MemberRepository memberRepository;
+    private final TodoListRepository todoListRepository;
+    private final TodoRepository todoRepository;
+
+    public TodoResponse addTodo(TodoRequest todoRequest) {
+        String socialId = getCurrentUserId();
+        Member member = memberRepository.findBySocialId(socialId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        Optional<TodoList> todoListOptional = todoListRepository.findByMember(member);
+        TodoList todoList;
+        if (todoListOptional.isEmpty()) {
+            todoList = new TodoList(member);
+            todoListRepository.save(todoList);
+        } else {
+            todoList = todoListOptional.get();
+        }
+        Todo todo = new Todo(todoRequest.getDate(), todoRequest.getTask(), todoList);
+        System.out.println("name : " + todoRequest.getTask());
+
+        System.out.println("date : " + todoRequest.getDate());
+        todo.addTodoList(todoList);
+        todoList.addTask(todo);
+
+        todoRepository.save(todo);
+        return convertToTodoResponse(todo);
+    }
+
+    public TodoResponse updateTodoTask(UpdateTodoTaskRequest updateTodoTaskRequest) {
+        Todo todo = todoRepository.findById(updateTodoTaskRequest.getTodoId()).orElseThrow(TodoNotFoundException::new);
+        String socialId = getCurrentUserId();
+        if (!todo.getTodoList().getMember().getSocialId().equals(socialId)) {
+            throw new UnauthorizedAccessException();
+        }
+        todo.updateTask(updateTodoTaskRequest.getTask());
+        todoRepository.save(todo);
+        return convertToTodoResponse(todo);
+    }
+
+    public TodoResponse updateTodoDate(UpdateTodoDateRequest updateTodoDateRequest) {
+        Todo todo = todoRepository.findById(updateTodoDateRequest.getTodoId()).orElseThrow(TodoNotFoundException::new);
+        String socialId = getCurrentUserId();
+        if (!todo.getTodoList().getMember().getSocialId().equals(socialId)) {
+            throw new UnauthorizedAccessException();
+        }
+        todo.updateDate(updateTodoDateRequest.getDate());
+        todoRepository.save(todo);
+        return convertToTodoResponse(todo);
+    }
+
+    public TodoResponse updateTodoCompletion(UpdateTodoCompletionRequest updateTodoCompletionRequest) {
+        Todo todo = todoRepository.findById(updateTodoCompletionRequest.getTodoId())
+                .orElseThrow(TodoNotFoundException::new);
+        String socialId = getCurrentUserId();
+        if (!todo.getTodoList().getMember().getSocialId().equals(socialId)) {
+            throw new UnauthorizedAccessException();
+        }
+        todo.updateCompleted(updateTodoCompletionRequest.isCompleted());
+        todoRepository.save(todo);
+        return convertToTodoResponse(todo);
+    }
+
+    public void deleteTodo(Long todoId) {
+        Todo todo = todoRepository.findById(todoId)
+                .orElseThrow(TodoNotFoundException::new);
+        String socialId = getCurrentUserId();
+        if (!todo.getTodoList().getMember().getSocialId().equals(socialId)) {
+            throw new UnauthorizedAccessException();
+        }
+        todoRepository.delete(todo);
+    }
+
+    private TodoResponse convertToTodoResponse(Todo todo) {
+        return new TodoResponse(todo.getDate(), todo.getTask(), todo.isCompleted());
+    }
+
+
+    private String getCurrentUserId() {
+        String socialId = SecurityContextHolder.getContext().getAuthentication().getName();
+
+        return socialId;
+    }
+}


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/todo-list` -> `develop`

### 변경 사항
- 회원별 TodoList 생성 및 관리 기능 추가
  - 회원의 socialId를 기반으로 TodoList를 조회
  - 해당 회원의 TodoList가 존재하지 않을 경우, 자동으로 생성 후 관리
- TodoList와 Todo 객체 간의 양방향 연관관계 설정
  - TodoList와 Todo 간 1:N 관계를 설정하여, 특정 TodoList에 여러 개의 Todo 추가 가능
  - 연관관계 매핑을 통해 회원별 할일 관리 기능 강화
- Todo 생성 기능 추가
  - 회원의 socialId를 기반으로 새로운 Todo 추가
  - Todo 추가 시 task(할일 내용), date(날짜) 정보를 함께 저장
  - 특정 회원의 TodoList가 존재하지 않는 경우, 자동으로 생성 후 Todo 추가
- Todo 조회 기능 추가
  - 특정 회원의 socialId와 날짜를 기준으로 해당 날짜의 Todo 목록 조회
  - 요청된 날짜에 해당하는 Todo가 없을 경우 빈 목록 반환
- Todo 할일명 수정 기능 추가
  - todoId를 기준으로 특정 Todo의 할일명(task) 수정 가능
  - 요청된 할일명으로 업데이트 후 변경된 정보 반환
- Todo 날짜 수정 기능 추가
  - todoId를 기준으로 특정 Todo의 날짜(date) 수정 가능
  - 요청된 날짜로 업데이트 후 변경된 정보 반환
- Todo 삭제 기능 추가
  - todoId를 기반으로 특정 Todo 삭제
  - 삭제 후 해당 TodoList가 비어 있다면, 필요 시 TodoList도 함께 삭제 가능하도록 고려