### PR TITLE
feat: 개인 시간표 CRUD 기능 구현

### DIFF
--- a/src/main/java/yerong/wedle/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/yerong/wedle/common/exception/GlobalExceptionHandler.java
@@ -38,6 +38,8 @@ import yerong.wedle.school.exception.SchoolChangeNotAllowedException;
 import yerong.wedle.school.exception.SchoolNotFoundException;
 import yerong.wedle.schoolcalendar.exception.SchoolCalendarNotFoundException;
 import yerong.wedle.star.exception.StarNotFoundException;
+import yerong.wedle.timetable.personalTimetable.exception.PersonalScheduleNotFoundException;
+import yerong.wedle.timetable.personalTimetable.exception.PersonalTimetableNotFoundException;
 import yerong.wedle.timetable.schoolTimetable.exception.SchoolScheduleNotFoundException;
 import yerong.wedle.timetable.schoolTimetable.exception.SchoolTimetableNotFoundException;
 import yerong.wedle.todo.exception.TodoNotFoundException;
@@ -428,6 +430,27 @@ public class GlobalExceptionHandler {
         ErrorResponse errorResponse = new ErrorResponse(
                 ResponseCode.SCHOOL_SCHEDULE_NOT_FOUND.getCode(),
                 ResponseCode.SCHOOL_TIMETABLE_NOT_FOUND.getMessage(),
+                LocalDateTime.now().format(FORMATTER)
+        );
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
+
+    @ExceptionHandler(PersonalTimetableNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handlePersonalTimetableNotFoundException(
+            PersonalTimetableNotFoundException ex) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                ResponseCode.PERSONAL_TIMETABLE_NOT_FOUND.getCode(),
+                ResponseCode.PERSONAL_TIMETABLE_NOT_FOUND.getMessage(),
+                LocalDateTime.now().format(FORMATTER)
+        );
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
+
+    @ExceptionHandler(PersonalScheduleNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handlePersonalScheduleNotFoundException(PersonalScheduleNotFoundException ex) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                ResponseCode.PERSONAL_SCHEDULE_NOT_FOUND.getCode(),
+                ResponseCode.PERSONAL_SCHEDULE_NOT_FOUND.getMessage(),
                 LocalDateTime.now().format(FORMATTER)
         );
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);

--- a/src/main/java/yerong/wedle/common/exception/ResponseCode.java
+++ b/src/main/java/yerong/wedle/common/exception/ResponseCode.java
@@ -85,7 +85,10 @@ public enum ResponseCode {
     TODO_NOT_FOUND("404", "할일을 찾을 수 없습니다."),
 
     SCHOOL_TIMETABLE_NOT_FOUND("404", "학교 시간표를 찾을 수 없습니다."),
-    SCHOOL_SCHEDULE_NOT_FOUND("404", "학교 시간표 스케줄을 찾을 수 없습니다.");
+    SCHOOL_SCHEDULE_NOT_FOUND("404", "학교 시간표 스케줄을 찾을 수 없습니다."),
+
+    PERSONAL_TIMETABLE_NOT_FOUND("404", "개인 시간표를 찾을 수 없습니다."),
+    PERSONAL_SCHEDULE_NOT_FOUND("404", "개인 시간표 스케줄을 찾을 수 없습니다.");
 
 
     private final String code;

--- a/src/main/java/yerong/wedle/timetable/DayOfWeek.java
+++ b/src/main/java/yerong/wedle/timetable/DayOfWeek.java
@@ -1,4 +1,4 @@
-package yerong.wedle.timetable.schoolTimetable.domain;
+package yerong.wedle.timetable;
 
 public enum DayOfWeek {
     SUNDAY("일요일"), MONDAY("월요일"), TUESDAY("화요일"), WEDNESDAY("수요일"), THURSDAY("목요일"), FRIDAY("금요일"), SATURDAY("토요일");

--- a/src/main/java/yerong/wedle/timetable/personalTimetable/controller/PersonalTimetableApiController.java
+++ b/src/main/java/yerong/wedle/timetable/personalTimetable/controller/PersonalTimetableApiController.java
@@ -1,0 +1,85 @@
+package yerong.wedle.timetable.personalTimetable.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import yerong.wedle.timetable.personalTimetable.dto.PersonalScheduleRequest;
+import yerong.wedle.timetable.personalTimetable.dto.PersonalScheduleResponse;
+import yerong.wedle.timetable.personalTimetable.dto.PersonalTimetableResponse;
+import yerong.wedle.timetable.personalTimetable.service.PersonalTimetableService;
+
+@Tag(name = "Personal-Timetable API", description = "개인 시간표 API")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/personal-timetable")
+public class PersonalTimetableApiController {
+    private final PersonalTimetableService personalTimetableService;
+
+    @Operation(
+            summary = "개인 시간표 조회",
+            description = "생성한 개인 시간표를 반환합니다."
+    )
+    @GetMapping()
+    public ResponseEntity<PersonalTimetableResponse> getPersonalTimetable() {
+        PersonalTimetableResponse personalTimetable = personalTimetableService.getPersonalTimetable();
+        return ResponseEntity.ok(personalTimetable);
+    }
+
+    @Operation(
+            summary = "개인 시간표 생성",
+            description = "개인 시간표를 생성합니다."
+    )
+    @PostMapping("/create")
+    public ResponseEntity<String> createPersonalTimetable() {
+        personalTimetableService.createPersonalTimetable();
+        return ResponseEntity.ok("개인 시간표가 성공적으로 생성되었습니다.");
+    }
+
+    @Operation(
+            summary = "시간표 비우기",
+            description = "시간표 내의 모든 스케줄을 삭제합니다."
+    )
+    @DeleteMapping("/clear")
+    public ResponseEntity<String> clearPersonalTimetable() {
+        personalTimetableService.clearTimetable();
+        return ResponseEntity.ok("개인 시간표의 모든 스케줄이 삭제되었습니다.");
+    }
+
+    @Operation(
+            summary = "스케줄 생성",
+            description = "개인 시간표에 새로운 스케줄을 추가합니다."
+    )
+    @PostMapping("/{timetableId}/schedule")
+    public ResponseEntity<String> createSchedule(@RequestBody PersonalScheduleRequest request) {
+        personalTimetableService.createSchedule(request);
+        return ResponseEntity.ok("개인 스케줄이 성공적으로 생성되었습니다.");
+    }
+
+    @Operation(
+            summary = "스케줄 삭제",
+            description = "주어진 ID의 스케줄을 삭제합니다."
+    )
+    @DeleteMapping("/schedule/{scheduleId}")
+    public ResponseEntity<String> deleteSchedule(@PathVariable Long scheduleId) {
+        personalTimetableService.deleteSchedule(scheduleId);
+        return ResponseEntity.ok("개인 스케줄이 삭제되었습니다.");
+    }
+
+    @Operation(
+            summary = "스케줄 조회",
+            description = "주어진 ID의 스케줄을 조회합니다."
+    )
+    @GetMapping("/schedule/{scheduleId}")
+    public ResponseEntity<PersonalScheduleResponse> getScheduleById(@PathVariable Long scheduleId) {
+        PersonalScheduleResponse response = personalTimetableService.getScheduleById(scheduleId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/yerong/wedle/timetable/personalTimetable/domain/PersonalSchedule.java
+++ b/src/main/java/yerong/wedle/timetable/personalTimetable/domain/PersonalSchedule.java
@@ -1,4 +1,4 @@
-package yerong.wedle.timetable.schoolTimetable.domain;
+package yerong.wedle.timetable.personalTimetable.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -9,6 +9,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,39 +19,40 @@ import yerong.wedle.timetable.DayOfWeek;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class SchoolSchedule {
+public class PersonalSchedule {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "school_timetable_id", nullable = false)
-    private SchoolTimetable schoolTimetable;
+    @JoinColumn(name = "personal_timetable_id", nullable = false)
+    private PersonalTimetable personalTimetable;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private DayOfWeek dayOfWeek;
 
     @Column(nullable = false)
-    private int period;
+    private String title;
 
     @Column(nullable = false)
-    private String subject;
+    private LocalTime startTime;
 
-    private String teacher;
+    @Column(nullable = false)
+    private LocalTime endTime;
 
     @Column(nullable = false)
     private String color;
 
     @Builder
-    public SchoolSchedule(SchoolTimetable schoolTimetable, int period, String subject, String teacher, String color,
-                          DayOfWeek dayOfWeek) {
-        this.schoolTimetable = schoolTimetable;
-        this.period = period;
-        this.subject = subject;
-        this.teacher = teacher;
-        this.color = color;
+    public PersonalSchedule(PersonalTimetable personalTimetable, DayOfWeek dayOfWeek, String title, LocalTime startTime,
+                            LocalTime endTime, String color) {
+        this.personalTimetable = personalTimetable;
         this.dayOfWeek = dayOfWeek;
+        this.title = title;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.color = color;
     }
 }

--- a/src/main/java/yerong/wedle/timetable/personalTimetable/domain/PersonalTimetable.java
+++ b/src/main/java/yerong/wedle/timetable/personalTimetable/domain/PersonalTimetable.java
@@ -1,0 +1,55 @@
+package yerong.wedle.timetable.personalTimetable.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import yerong.wedle.common.domain.Visibility;
+import yerong.wedle.member.domain.Member;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PersonalTimetable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Visibility visibility = Visibility.PRIVATE;
+
+    @OneToMany(mappedBy = "personalTimetable", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PersonalSchedule> schedules;
+
+    @Builder
+    public PersonalTimetable(Member member, String title, Visibility visibility) {
+        this.member = member;
+        this.visibility = visibility;
+    }
+
+    public void addSchedules(PersonalSchedule personalSchedule) {
+        this.schedules.add(personalSchedule);
+    }
+
+    public void updateVisibility(Visibility visibility) {
+        this.visibility = visibility;
+    }
+}

--- a/src/main/java/yerong/wedle/timetable/personalTimetable/dto/PersonalScheduleRequest.java
+++ b/src/main/java/yerong/wedle/timetable/personalTimetable/dto/PersonalScheduleRequest.java
@@ -1,0 +1,20 @@
+package yerong.wedle.timetable.personalTimetable.dto;
+
+import lombok.Data;
+
+@Data
+public class PersonalScheduleRequest {
+    private String day;
+    private String startTime;
+    private String endTime;
+    private String title;
+    private String color;
+
+    public PersonalScheduleRequest(String day, String startTime, String endTime, String title, String color) {
+        this.day = day;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.title = title;
+        this.color = color;
+    }
+}

--- a/src/main/java/yerong/wedle/timetable/personalTimetable/dto/PersonalScheduleResponse.java
+++ b/src/main/java/yerong/wedle/timetable/personalTimetable/dto/PersonalScheduleResponse.java
@@ -1,0 +1,25 @@
+package yerong.wedle.timetable.personalTimetable.dto;
+
+import java.time.LocalTime;
+import lombok.Data;
+
+@Data
+public class PersonalScheduleResponse {
+    private Long personalScheduleId;
+    private String day;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private String title;
+    private String color;
+
+    public PersonalScheduleResponse(Long personalScheduleId, String day, LocalTime startTime, LocalTime endTime,
+                                    String title,
+                                    String color) {
+        this.personalScheduleId = personalScheduleId;
+        this.day = day;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.title = title;
+        this.color = color;
+    }
+}

--- a/src/main/java/yerong/wedle/timetable/personalTimetable/dto/PersonalTimetableResponse.java
+++ b/src/main/java/yerong/wedle/timetable/personalTimetable/dto/PersonalTimetableResponse.java
@@ -1,0 +1,15 @@
+package yerong.wedle.timetable.personalTimetable.dto;
+
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class PersonalTimetableResponse {
+    private Long personalTimetableId;
+    private List<PersonalScheduleResponse> schedules;
+
+    public PersonalTimetableResponse(Long schoolTimetableId, List<PersonalScheduleResponse> schedules) {
+        this.personalTimetableId = schoolTimetableId;
+        this.schedules = schedules;
+    }
+}

--- a/src/main/java/yerong/wedle/timetable/personalTimetable/exception/PersonalScheduleNotFoundException.java
+++ b/src/main/java/yerong/wedle/timetable/personalTimetable/exception/PersonalScheduleNotFoundException.java
@@ -1,0 +1,10 @@
+package yerong.wedle.timetable.personalTimetable.exception;
+
+import yerong.wedle.common.exception.CustomException;
+import yerong.wedle.common.exception.ResponseCode;
+
+public class PersonalScheduleNotFoundException extends CustomException {
+    public PersonalScheduleNotFoundException() {
+        super(ResponseCode.PERSONAL_SCHEDULE_NOT_FOUND);
+    }
+}

--- a/src/main/java/yerong/wedle/timetable/personalTimetable/exception/PersonalTimetableNotFoundException.java
+++ b/src/main/java/yerong/wedle/timetable/personalTimetable/exception/PersonalTimetableNotFoundException.java
@@ -1,0 +1,10 @@
+package yerong.wedle.timetable.personalTimetable.exception;
+
+import yerong.wedle.common.exception.CustomException;
+import yerong.wedle.common.exception.ResponseCode;
+
+public class PersonalTimetableNotFoundException extends CustomException {
+    public PersonalTimetableNotFoundException() {
+        super(ResponseCode.PERSONAL_TIMETABLE_NOT_FOUND);
+    }
+}

--- a/src/main/java/yerong/wedle/timetable/personalTimetable/repository/PersonalScheduleRepository.java
+++ b/src/main/java/yerong/wedle/timetable/personalTimetable/repository/PersonalScheduleRepository.java
@@ -1,0 +1,7 @@
+package yerong.wedle.timetable.personalTimetable.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import yerong.wedle.timetable.personalTimetable.domain.PersonalSchedule;
+
+public interface PersonalScheduleRepository extends JpaRepository<PersonalSchedule, Long> {
+}

--- a/src/main/java/yerong/wedle/timetable/personalTimetable/repository/PersonalTimetableRepository.java
+++ b/src/main/java/yerong/wedle/timetable/personalTimetable/repository/PersonalTimetableRepository.java
@@ -1,0 +1,10 @@
+package yerong.wedle.timetable.personalTimetable.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import yerong.wedle.member.domain.Member;
+import yerong.wedle.timetable.personalTimetable.domain.PersonalTimetable;
+
+public interface PersonalTimetableRepository extends JpaRepository<PersonalTimetable, Long> {
+    Optional<PersonalTimetable> findByMember(Member member);
+}

--- a/src/main/java/yerong/wedle/timetable/personalTimetable/service/PersonalTimetableService.java
+++ b/src/main/java/yerong/wedle/timetable/personalTimetable/service/PersonalTimetableService.java
@@ -1,0 +1,156 @@
+package yerong.wedle.timetable.personalTimetable.service;
+
+import jakarta.transaction.Transactional;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import yerong.wedle.common.domain.Visibility;
+import yerong.wedle.member.domain.Member;
+import yerong.wedle.member.exception.MemberNotFoundException;
+import yerong.wedle.member.exception.UnauthorizedAccessException;
+import yerong.wedle.member.repository.MemberRepository;
+import yerong.wedle.timetable.DayOfWeek;
+import yerong.wedle.timetable.personalTimetable.domain.PersonalSchedule;
+import yerong.wedle.timetable.personalTimetable.domain.PersonalTimetable;
+import yerong.wedle.timetable.personalTimetable.dto.PersonalScheduleRequest;
+import yerong.wedle.timetable.personalTimetable.dto.PersonalScheduleResponse;
+import yerong.wedle.timetable.personalTimetable.dto.PersonalTimetableResponse;
+import yerong.wedle.timetable.personalTimetable.exception.PersonalScheduleNotFoundException;
+import yerong.wedle.timetable.personalTimetable.exception.PersonalTimetableNotFoundException;
+import yerong.wedle.timetable.personalTimetable.repository.PersonalScheduleRepository;
+import yerong.wedle.timetable.personalTimetable.repository.PersonalTimetableRepository;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PersonalTimetableService {
+    private final PersonalTimetableRepository personalTimetableRepository;
+    private final PersonalScheduleRepository personalScheduleRepository;
+    private final MemberRepository memberRepository;
+
+    public PersonalTimetableResponse getPersonalTimetable() {
+        String socialId = getCurrentUserId();
+        Member member = memberRepository.findBySocialId(socialId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        PersonalTimetable personalTimetable = personalTimetableRepository.findByMember(member)
+                .orElseThrow(
+                        PersonalTimetableNotFoundException::new);
+        return convertToPersonalTimetableResponse(personalTimetable);
+    }
+
+    public void createPersonalTimetable() {
+        String socialId = getCurrentUserId();
+        Member member = memberRepository.findBySocialId(socialId)
+                .orElseThrow(MemberNotFoundException::new);
+        PersonalTimetable personalTimetable = PersonalTimetable.builder()
+                .member(member)
+                .visibility(Visibility.PRIVATE)
+                .build();
+        personalTimetableRepository.save(personalTimetable);
+    }
+
+    public void clearTimetable() {
+        String socialId = getCurrentUserId();
+        Member member = memberRepository.findBySocialId(socialId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        PersonalTimetable personalTimetable = personalTimetableRepository.findByMember(member)
+                .orElseThrow(
+                        PersonalTimetableNotFoundException::new);
+        personalScheduleRepository.deleteInBatch(personalTimetable.getSchedules());
+    }
+
+    public void createSchedule(PersonalScheduleRequest personalScheduleRequest) {
+        String socialId = getCurrentUserId();
+        Member member = memberRepository.findBySocialId(socialId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        PersonalTimetable personalTimetable = personalTimetableRepository.findByMember(member)
+                .orElseThrow(
+                        PersonalTimetableNotFoundException::new);
+        DayOfWeek dayOfWeek = getDayOfWeekFromRequest(personalScheduleRequest.getDay());
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
+        LocalTime startTime = LocalTime.parse(personalScheduleRequest.getStartTime(), formatter);
+        LocalTime endTime = LocalTime.parse(personalScheduleRequest.getEndTime(), formatter);
+
+        PersonalSchedule personalSchedule = PersonalSchedule.builder()
+                .personalTimetable(personalTimetable)
+                .dayOfWeek(dayOfWeek)
+                .title(personalScheduleRequest.getTitle())
+                .startTime(startTime)
+                .endTime(endTime)
+                .color(personalScheduleRequest.getColor())
+                .build();
+        personalScheduleRepository.save(personalSchedule);
+        personalTimetable.addSchedules(personalSchedule);
+    }
+
+    public void deleteSchedule(Long scheduleId) {
+        String socialId = getCurrentUserId();
+        PersonalSchedule personalSchedule = personalScheduleRepository.findById(scheduleId)
+                .orElseThrow(PersonalScheduleNotFoundException::new);
+        if (!personalSchedule.getPersonalTimetable().getMember().getSocialId().equals(socialId)) {
+            throw new UnauthorizedAccessException();
+        }
+        personalScheduleRepository.delete(personalSchedule);
+    }
+
+    public PersonalScheduleResponse getScheduleById(Long scheduleId) {
+        PersonalSchedule personalSchedule = personalScheduleRepository.findById(scheduleId)
+                .orElseThrow(PersonalScheduleNotFoundException::new);
+
+        return convertToPersonalScheduleResponse(personalSchedule);
+    }
+
+    private PersonalTimetableResponse convertToPersonalTimetableResponse(PersonalTimetable personalTimetable) {
+        List<PersonalScheduleResponse> personalScheduleResponses = personalTimetable.getSchedules().stream()
+                .map(schedule -> new PersonalScheduleResponse(
+                        schedule.getId(),
+                        schedule.getDayOfWeek().getDay(),
+                        schedule.getStartTime(),
+                        schedule.getEndTime(),
+                        schedule.getTitle(),
+                        schedule.getColor()
+                )).collect(Collectors.toList());
+        return new PersonalTimetableResponse(personalTimetable.getId(), personalScheduleResponses);
+    }
+
+    private PersonalScheduleResponse convertToPersonalScheduleResponse(PersonalSchedule personalSchedule) {
+        return new PersonalScheduleResponse(personalSchedule.getId(), personalSchedule.getDayOfWeek().getDay(),
+                personalSchedule.getStartTime(), personalSchedule.getEndTime(), personalSchedule.getTitle(),
+                personalSchedule.getColor());
+    }
+
+    private DayOfWeek getDayOfWeekFromRequest(String dayOfWeekRequest) {
+        switch (dayOfWeekRequest) {
+            case "월요일":
+                return DayOfWeek.MONDAY;
+            case "화요일":
+                return DayOfWeek.TUESDAY;
+            case "수요일":
+                return DayOfWeek.WEDNESDAY;
+            case "목요일":
+                return DayOfWeek.THURSDAY;
+            case "금요일":
+                return DayOfWeek.FRIDAY;
+            case "토요일":
+                return DayOfWeek.SATURDAY;
+            case "일요일":
+                return DayOfWeek.SUNDAY;
+            default:
+                throw new IllegalArgumentException("Invalid day of week: " + dayOfWeekRequest);
+        }
+    }
+
+    private String getCurrentUserId() {
+        String socialId = SecurityContextHolder.getContext().getAuthentication().getName();
+
+        return socialId;
+    }
+}

--- a/src/main/java/yerong/wedle/timetable/schoolTimetable/service/SchoolTimetableService.java
+++ b/src/main/java/yerong/wedle/timetable/schoolTimetable/service/SchoolTimetableService.java
@@ -6,11 +6,12 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import yerong.wedle.common.domain.Visibility;
 import yerong.wedle.member.domain.Member;
 import yerong.wedle.member.exception.MemberNotFoundException;
 import yerong.wedle.member.exception.UnauthorizedAccessException;
 import yerong.wedle.member.repository.MemberRepository;
-import yerong.wedle.timetable.schoolTimetable.domain.DayOfWeek;
+import yerong.wedle.timetable.DayOfWeek;
 import yerong.wedle.timetable.schoolTimetable.domain.SchoolSchedule;
 import yerong.wedle.timetable.schoolTimetable.domain.SchoolTimetable;
 import yerong.wedle.timetable.schoolTimetable.dto.SchoolScheduleRequest;
@@ -48,6 +49,7 @@ public class SchoolTimetableService {
         SchoolTimetable schoolTimetable = SchoolTimetable.builder()
                 .member(member)
                 .school(member.getSchool())
+                .visibility(Visibility.PRIVATE)
                 .title(title)
                 .build();
         schoolTimetableRepository.save(schoolTimetable);


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/personal-timetable` -> `develop`

### 변경 사항
- 회원 개인 시간표 생성 및 조회
  - 사용자의 socialId를 기반으로 새로운 시간표를 생성하고, 해당 시간표를 조회할 수 있도록 기능 추가
  - 만약 사용자가 기존 시간표를 가지고 있지 않으면 자동으로 새로운 시간표가 생성됩됨
- 시간표 내 스케줄 관리:
  - 사용자가 자신의 시간표에 새로운 스케줄을 추가할 수 있는 기능 추가
  - 사용자가 시간표 내에서 특정 스케줄을 수정하거나 삭제 가능
- 시간표 비우기 기능:
  - 삭제된 스케줄은 personalScheduleRepository.deleteInBatch()를 사용하여 일괄 삭제되며, 연관된 데이터들도 함께 삭제
- 시간표 정보 수정: 
  - 사용자는 시간표의 내용을 수정할 수 있다.

