### PR TITLE
refactor: 이미 일정이 존재하는 경우 저장되지 않도록 수정

### DIFF
--- a/src/main/java/yerong/wedle/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/yerong/wedle/common/exception/GlobalExceptionHandler.java
@@ -38,8 +38,10 @@ import yerong.wedle.school.exception.SchoolChangeNotAllowedException;
 import yerong.wedle.school.exception.SchoolNotFoundException;
 import yerong.wedle.schoolcalendar.exception.SchoolCalendarNotFoundException;
 import yerong.wedle.star.exception.StarNotFoundException;
+import yerong.wedle.timetable.personalTimetable.exception.PersonalScheduleAlreadyExistsException;
 import yerong.wedle.timetable.personalTimetable.exception.PersonalScheduleNotFoundException;
 import yerong.wedle.timetable.personalTimetable.exception.PersonalTimetableNotFoundException;
+import yerong.wedle.timetable.schoolTimetable.exception.SchoolScheduleAlreadyExistsException;
 import yerong.wedle.timetable.schoolTimetable.exception.SchoolScheduleNotFoundException;
 import yerong.wedle.timetable.schoolTimetable.exception.SchoolTimetableNotFoundException;
 import yerong.wedle.todo.exception.TodoNotFoundException;
@@ -454,6 +456,28 @@ public class GlobalExceptionHandler {
                 LocalDateTime.now().format(FORMATTER)
         );
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
+
+    @ExceptionHandler(SchoolScheduleAlreadyExistsException.class)
+    public ResponseEntity<ErrorResponse> handleSchoolScheduleAlreadyExistsException(
+            SchoolScheduleAlreadyExistsException ex) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                ResponseCode.SCHOOL_SCHEDULE_ALREADY_EXISTS.getCode(),
+                ResponseCode.SCHOOL_SCHEDULE_ALREADY_EXISTS.getMessage(),
+                LocalDateTime.now().format(FORMATTER)
+        );
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
+    }
+
+    @ExceptionHandler(PersonalScheduleAlreadyExistsException.class)
+    public ResponseEntity<ErrorResponse> handlePersonalScheduleAlreadyExistsException(
+            PersonalScheduleAlreadyExistsException ex) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                ResponseCode.PERSONAL_SCHEDULE_ALREADY_EXISTS.getCode(),
+                ResponseCode.PERSONAL_SCHEDULE_ALREADY_EXISTS.getMessage(),
+                LocalDateTime.now().format(FORMATTER)
+        );
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/yerong/wedle/common/exception/ResponseCode.java
+++ b/src/main/java/yerong/wedle/common/exception/ResponseCode.java
@@ -88,7 +88,10 @@ public enum ResponseCode {
     SCHOOL_SCHEDULE_NOT_FOUND("404", "학교 시간표 스케줄을 찾을 수 없습니다."),
 
     PERSONAL_TIMETABLE_NOT_FOUND("404", "개인 시간표를 찾을 수 없습니다."),
-    PERSONAL_SCHEDULE_NOT_FOUND("404", "개인 시간표 스케줄을 찾을 수 없습니다.");
+    PERSONAL_SCHEDULE_NOT_FOUND("404", "개인 시간표 스케줄을 찾을 수 없습니다."),
+
+    SCHOOL_SCHEDULE_ALREADY_EXISTS("409", "해당 요일과 교시에 이미 일정이 존재합니다."),
+    PERSONAL_SCHEDULE_ALREADY_EXISTS("409", "해당 시간에 이미 일정이 존재합니다.");
 
 
     private final String code;

--- a/src/main/java/yerong/wedle/timetable/personalTimetable/exception/PersonalScheduleAlreadyExistsException.java
+++ b/src/main/java/yerong/wedle/timetable/personalTimetable/exception/PersonalScheduleAlreadyExistsException.java
@@ -1,0 +1,10 @@
+package yerong.wedle.timetable.personalTimetable.exception;
+
+import yerong.wedle.common.exception.CustomException;
+import yerong.wedle.common.exception.ResponseCode;
+
+public class PersonalScheduleAlreadyExistsException extends CustomException {
+    public PersonalScheduleAlreadyExistsException() {
+        super(ResponseCode.PERSONAL_SCHEDULE_ALREADY_EXISTS);
+    }
+}

--- a/src/main/java/yerong/wedle/timetable/personalTimetable/repository/PersonalScheduleRepository.java
+++ b/src/main/java/yerong/wedle/timetable/personalTimetable/repository/PersonalScheduleRepository.java
@@ -1,7 +1,14 @@
 package yerong.wedle.timetable.personalTimetable.repository;
 
+import java.time.LocalTime;
 import org.springframework.data.jpa.repository.JpaRepository;
+import yerong.wedle.timetable.DayOfWeek;
 import yerong.wedle.timetable.personalTimetable.domain.PersonalSchedule;
+import yerong.wedle.timetable.personalTimetable.domain.PersonalTimetable;
 
 public interface PersonalScheduleRepository extends JpaRepository<PersonalSchedule, Long> {
+    boolean existsByPersonalTimetableAndDayOfWeekAndStartTimeBeforeAndEndTimeAfter(PersonalTimetable personalTimetable,
+                                                                                   DayOfWeek dayOfWeek,
+                                                                                   LocalTime endTime,
+                                                                                   LocalTime startTime);
 }

--- a/src/main/java/yerong/wedle/timetable/personalTimetable/service/PersonalTimetableService.java
+++ b/src/main/java/yerong/wedle/timetable/personalTimetable/service/PersonalTimetableService.java
@@ -19,6 +19,7 @@ import yerong.wedle.timetable.personalTimetable.domain.PersonalTimetable;
 import yerong.wedle.timetable.personalTimetable.dto.PersonalScheduleRequest;
 import yerong.wedle.timetable.personalTimetable.dto.PersonalScheduleResponse;
 import yerong.wedle.timetable.personalTimetable.dto.PersonalTimetableResponse;
+import yerong.wedle.timetable.personalTimetable.exception.PersonalScheduleAlreadyExistsException;
 import yerong.wedle.timetable.personalTimetable.exception.PersonalScheduleNotFoundException;
 import yerong.wedle.timetable.personalTimetable.exception.PersonalTimetableNotFoundException;
 import yerong.wedle.timetable.personalTimetable.repository.PersonalScheduleRepository;
@@ -78,6 +79,13 @@ public class PersonalTimetableService {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
         LocalTime startTime = LocalTime.parse(personalScheduleRequest.getStartTime(), formatter);
         LocalTime endTime = LocalTime.parse(personalScheduleRequest.getEndTime(), formatter);
+
+        boolean scheduleExists = personalScheduleRepository.existsByPersonalTimetableAndDayOfWeekAndStartTimeBeforeAndEndTimeAfter(
+                personalTimetable, dayOfWeek, endTime, startTime);
+
+        if (scheduleExists) {
+            throw new PersonalScheduleAlreadyExistsException();
+        }
 
         PersonalSchedule personalSchedule = PersonalSchedule.builder()
                 .personalTimetable(personalTimetable)

--- a/src/main/java/yerong/wedle/timetable/schoolTimetable/exception/SchoolScheduleAlreadyExistsException.java
+++ b/src/main/java/yerong/wedle/timetable/schoolTimetable/exception/SchoolScheduleAlreadyExistsException.java
@@ -1,0 +1,10 @@
+package yerong.wedle.timetable.schoolTimetable.exception;
+
+import yerong.wedle.common.exception.CustomException;
+import yerong.wedle.common.exception.ResponseCode;
+
+public class SchoolScheduleAlreadyExistsException extends CustomException {
+    public SchoolScheduleAlreadyExistsException() {
+        super(ResponseCode.SCHOOL_SCHEDULE_ALREADY_EXISTS);
+    }
+}

--- a/src/main/java/yerong/wedle/timetable/schoolTimetable/repository/SchoolScheduleRepository.java
+++ b/src/main/java/yerong/wedle/timetable/schoolTimetable/repository/SchoolScheduleRepository.java
@@ -1,7 +1,11 @@
 package yerong.wedle.timetable.schoolTimetable.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import yerong.wedle.timetable.DayOfWeek;
 import yerong.wedle.timetable.schoolTimetable.domain.SchoolSchedule;
+import yerong.wedle.timetable.schoolTimetable.domain.SchoolTimetable;
 
 public interface SchoolScheduleRepository extends JpaRepository<SchoolSchedule, Long> {
+    boolean existsBySchoolTimetableAndDayOfWeekAndPeriod(SchoolTimetable schoolTimetable, DayOfWeek dayOfWeek,
+                                                         int period);
 }

--- a/src/main/java/yerong/wedle/timetable/schoolTimetable/service/SchoolTimetableService.java
+++ b/src/main/java/yerong/wedle/timetable/schoolTimetable/service/SchoolTimetableService.java
@@ -17,6 +17,7 @@ import yerong.wedle.timetable.schoolTimetable.domain.SchoolTimetable;
 import yerong.wedle.timetable.schoolTimetable.dto.SchoolScheduleRequest;
 import yerong.wedle.timetable.schoolTimetable.dto.SchoolScheduleResponse;
 import yerong.wedle.timetable.schoolTimetable.dto.SchoolTimetableResponse;
+import yerong.wedle.timetable.schoolTimetable.exception.SchoolScheduleAlreadyExistsException;
 import yerong.wedle.timetable.schoolTimetable.exception.SchoolScheduleNotFoundException;
 import yerong.wedle.timetable.schoolTimetable.exception.SchoolTimetableNotFoundException;
 import yerong.wedle.timetable.schoolTimetable.repository.SchoolScheduleRepository;
@@ -75,6 +76,13 @@ public class SchoolTimetableService {
                 .orElseThrow(
                         SchoolTimetableNotFoundException::new);
         DayOfWeek dayOfWeek = getDayOfWeekFromRequest(schoolScheduleRequest.getDay());
+
+        boolean scheduleExists = schoolScheduleRepository.existsBySchoolTimetableAndDayOfWeekAndPeriod(schoolTimetable,
+                dayOfWeek, schoolScheduleRequest.getPeriod());
+        if (scheduleExists) {
+            throw new SchoolScheduleAlreadyExistsException();
+        }
+
         SchoolSchedule schoolSchedule = SchoolSchedule.builder()
                 .schoolTimetable(schoolTimetable)
                 .dayOfWeek(dayOfWeek)


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/timetable-refactor` -> `develop`

### 변경 사항
- 동일한 요일과 시간대에 이미 일정이 등록되어 있을 경우 새로운 일정 저장을 막는 로직 추가
- 개인 시간표 수정  
  - `PersonalScheduleRepository`에 `existsByPersonalTimetableAndDayOfWeekAndStartTimeBeforeAndEndTimeAfter` 메서드 추가하여 시간 겹침 여부를 확인
  - 일정이 겹치는 경우 `PersonalScheduleAlreadyExistsException` 예외 처리
- 학교 시간표 수정  
  - `SchoolScheduleRepository`에 `existsBySchoolTimetableAndDayOfWeekAndPeriod` 메서드 추가하여 시간 겹침 여부를 확인
  - 일정이 겹치는 경우 `SchoolScheduleAlreadyExistsException` 예외 처리

