### PR TITLE
refactor: S3 프로필 이미지 업로드 및 삭제 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-admin:9.2.0'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
+    implementation 'software.amazon.awssdk:s3:2.21.5'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
 //    runtimeOnly 'com.h2database:h2'

--- a/src/main/java/yerong/wedle/common/config/AppConfig.java
+++ b/src/main/java/yerong/wedle/common/config/AppConfig.java
@@ -1,13 +1,36 @@
 package yerong.wedle.common.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 
 @Configuration
 public class AppConfig {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKeyId;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretAccessKey;
+
     @Bean
     public RestTemplate restTemplate() {
         return new RestTemplate();
+    }
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKeyId, secretAccessKey);
+        AwsCredentialsProvider provider = StaticCredentialsProvider.create(credentials);
+        return S3Client.builder()
+                .region(Region.AP_NORTHEAST_2)
+                .credentialsProvider(provider)
+                .build();
     }
 }

--- a/src/main/java/yerong/wedle/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/yerong/wedle/common/exception/GlobalExceptionHandler.java
@@ -314,13 +314,10 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleException(Exception ex) {
-        ErrorResponse errorResponse = new ErrorResponse(
-                ResponseCode.INTERNAL_SERVER_ERROR.getCode(),
-                "예상치 못한 오류가 발생했습니다.",
-                LocalDateTime.now().format(FORMATTER)
-        );
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    public ResponseEntity<String> handleException(Exception e) {
+        e.printStackTrace();
+        return ResponseEntity.status(500).body("Error: " + e.getMessage());
     }
+    
 
 }

--- a/src/main/java/yerong/wedle/common/s3/S3Service.java
+++ b/src/main/java/yerong/wedle/common/s3/S3Service.java
@@ -1,0 +1,61 @@
+package yerong.wedle.common.s3;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@RequiredArgsConstructor
+@Service
+public class S3Service {
+
+    private final S3Client s3Client;
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+    @Value("${cloud.aws.s3.url}")
+    private String url;
+
+    public String uploadProfileImage(MultipartFile file) {
+        String fileName = "profileImage/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
+        String contentType = getContentType(file.getOriginalFilename());
+
+        try {
+            s3Client.putObject(PutObjectRequest.builder()
+                            .bucket(bucketName)
+                            .key(fileName)
+                            .contentType(contentType)
+                            .build(),
+                    RequestBody.fromByteBuffer(ByteBuffer.wrap(file.getBytes())));
+            return url + fileName;
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to upload profile image", e);
+        }
+    }
+
+    public void deleteFile(String profileImageUrl) {
+        String fileName = profileImageUrl.replace(url, "");
+
+        try {
+            s3Client.deleteObject(builder -> builder.bucket(bucketName).key(fileName));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to delete profile image", e);
+        }
+    }
+
+    private String getContentType(String fileName) {
+        if (fileName.endsWith(".png") || fileName.endsWith(".PNG")) {
+            return "image/png";
+        } else if (fileName.endsWith(".jpg") || fileName.endsWith(".jpeg") || fileName.endsWith(".JPG")
+                || fileName.endsWith(".JPEG")) {
+            return "image/jpeg";
+        } else {
+            throw new RuntimeException("Unsupported file type");
+        }
+    }
+}

--- a/src/main/java/yerong/wedle/member/controller/MemberApiController.java
+++ b/src/main/java/yerong/wedle/member/controller/MemberApiController.java
@@ -12,11 +12,14 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 import yerong.wedle.member.dto.GradeAndClassRegistrationRequest;
 import yerong.wedle.member.dto.NicknameDuplicateResponse;
 import yerong.wedle.member.dto.NicknameRequest;
 import yerong.wedle.member.dto.NicknameResponse;
+import yerong.wedle.member.dto.ProfileImageResponse;
 import yerong.wedle.member.dto.SchoolRegistrationRequest;
 import yerong.wedle.member.service.MemberService;
 import yerong.wedle.school.service.SchoolService;
@@ -96,5 +99,29 @@ public class MemberApiController {
                                                       GradeAndClassRegistrationRequest gradeAndClassRegistrationRequest) {
         memberService.setGradeAndClass(gradeAndClassRegistrationRequest);
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "프로필 사진 제거", description = "프로필 사진을 제거하고 기본 이미지로 설정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "프로필 사진 제거 성공"),
+            @ApiResponse(responseCode = "404", description = "회원을 찾을 수 없음")
+    })
+    @PutMapping("/profile-image/remove")
+    public ResponseEntity<Void> removeProfileImage() {
+        memberService.removeProfileImage();
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "프로필 사진 변경", description = "프로필 사진을 변경합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "프로필 사진 변경 성공"),
+            @ApiResponse(responseCode = "404", description = "회원을 찾을 수 없음")
+    })
+    @PutMapping("/profile-image/update")
+    public ResponseEntity<ProfileImageResponse> updateProfileImage(
+            @RequestPart("profileImage") MultipartFile profileImageRequest) {
+        System.out.println("success");
+        ProfileImageResponse profileImageResponse = memberService.setProfileImage(profileImageRequest);
+        return ResponseEntity.ok(profileImageResponse);
     }
 }

--- a/src/main/java/yerong/wedle/member/domain/Member.java
+++ b/src/main/java/yerong/wedle/member/domain/Member.java
@@ -47,6 +47,7 @@ public class Member extends BaseTimeEntity {
     @Column(unique = true)
     private String nickname;
 
+    private String profileImageUrl;
     @ManyToOne
     @JoinColumn(name = "school_id")
     private School school;
@@ -84,5 +85,9 @@ public class Member extends BaseTimeEntity {
     public void setGradeAndClass(int grade, String className) {
         this.grade = grade;
         this.className = className;
+    }
+
+    public void setProfileImageUrl(String imageUrl) {
+        this.profileImageUrl = imageUrl;
     }
 }

--- a/src/main/java/yerong/wedle/member/dto/ProfileImageRequest.java
+++ b/src/main/java/yerong/wedle/member/dto/ProfileImageRequest.java
@@ -1,0 +1,12 @@
+package yerong.wedle.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+public class ProfileImageRequest {
+
+    @Schema(description = "프로필 사진", required = true)
+    private MultipartFile profileImage;
+}

--- a/src/main/java/yerong/wedle/member/dto/ProfileImageResponse.java
+++ b/src/main/java/yerong/wedle/member/dto/ProfileImageResponse.java
@@ -1,0 +1,15 @@
+package yerong.wedle.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@Builder
+@Data
+@NoArgsConstructor
+public class ProfileImageResponse {
+
+    private String profileImage;
+}

--- a/src/main/java/yerong/wedle/oauth/service/AuthService.java
+++ b/src/main/java/yerong/wedle/oauth/service/AuthService.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
@@ -35,6 +36,8 @@ public class AuthService {
     private final JwtProvider jwtProvider;
     private final RedisTemplate redisTemplate;
     private final JwtBlacklistService jwtBlacklistService;
+    @Value("${cloud.aws.s3.defaultImage}")
+    String defaultImageUrl;
 
     private static final String BEARER = "Bearer ";
 
@@ -52,6 +55,7 @@ public class AuthService {
                     .username(memberRequest.getName())
                     .role(Role.USER)
                     .isExistingMember(false)
+                    .profileImageUrl(defaultImageUrl)
                     .build();
             memberRepository.save(member);
         } else {


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/proofile-image` -> `develop`

### 변경 사항
- S3 이미지 업로드 및 삭제 기능 추가
  - PNG 및 JPG 파일을 S3에 업로드할 수 있도록 구현
  - `deleteFile` 메서드를 통해 S3에서 프로필 이미지를 삭제할 수 있도록 구현
  - 파일 확장자에 따라 contentType을 동적으로 설정하도록 수정


