### PR TITLE
Feature/post like

### DIFF
--- a/src/main/java/yerong/wedle/like/postLike/service/PostLikeService.java
+++ b/src/main/java/yerong/wedle/like/postLike/service/PostLikeService.java
@@ -23,6 +23,7 @@ import yerong.wedle.post.repository.PostRepository;
 @RequiredArgsConstructor
 @Transactional
 public class PostLikeService {
+    private static final int HOT_BOARD_THRESHOLD = 3;
 
     private final PostLikeRepository postLikeRepository;
     private final MemberRepository memberRepository;
@@ -32,8 +33,8 @@ public class PostLikeService {
     public void addLike(Long postId) {
         String socialId = getCurrentUserId();
         Member member = memberRepository.findBySocialId(socialId).orElseThrow(MemberNotFoundException::new);
-        Post post = postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
-
+        Post post = postRepository.findByIdWithPessimisticLock(postId)
+                .orElseThrow(PostNotFoundException::new);
         boolean alreadyLiked = postLikeRepository.existsByMemberAndPost(member, post);
         if (!alreadyLiked) {
             PostLike postLike = PostLike.builder()
@@ -41,11 +42,12 @@ public class PostLikeService {
                     .post(post)
                     .build();
             postLikeRepository.save(postLike);
-            post.increaseLike();
-            if (post.getLikeCount() >= 3) {
+
+            long likeCount = postLikeRepository.countByPostId(postId);
+
+            if (likeCount >= HOT_BOARD_THRESHOLD && !post.isHotBoard()) {
                 moveToHotBoard(post);
             }
-            postRepository.save(post);
         }
     }
 
@@ -65,7 +67,8 @@ public class PostLikeService {
     public void removeLike(Long postId) {
         String socialId = getCurrentUserId();
         Member member = memberRepository.findBySocialId(socialId).orElseThrow(MemberNotFoundException::new);
-        Post post = postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
+        Post post = postRepository.findByIdWithPessimisticLock(postId)
+                .orElseThrow(PostNotFoundException::new);
 
         PostLike postLike = postLikeRepository.findByMemberAndPost(member, post).orElseThrow(
                 PostNotFoundException::new);
@@ -73,15 +76,15 @@ public class PostLikeService {
         authorizeMember(postLike);
 
         postLikeRepository.delete(postLike);
+        long likeCount = postLikeRepository.countByPostId(postId);
 
-        post.decreaseLike();
-        if (post.getLikeCount() < 3) {
-            removeToHotBoard(post);
+        if (likeCount < HOT_BOARD_THRESHOLD && post.isHotBoard()) {
+            removeFromHotBoard(post);
         }
         postRepository.save(post);
     }
 
-    public void removeToHotBoard(Post post) {
+    public void removeFromHotBoard(Post post) {
         Community community = post.getBoard().getCommunity();
         Board hotboard = community.getBoards().stream()
                 .filter(board -> board.getType() == BoardType.HOT)
@@ -91,10 +94,6 @@ public class PostLikeService {
             post.setHotBoard(false);
             hotboard.removePost(post);
         }
-    }
-
-    public Long likeCount(Long postId) {
-        return postLikeRepository.countByPostId(postId);
     }
 
     private void authorizeMember(PostLike postLike) {

--- a/src/main/java/yerong/wedle/post/domain/Post.java
+++ b/src/main/java/yerong/wedle/post/domain/Post.java
@@ -44,10 +44,7 @@ public class Post extends BaseTimeEntity {
 
     @Column(nullable = false)
     private boolean isAnonymous;
-
-    @Column(nullable = false)
-    private int likeCount = 0;
-
+    
     @ManyToOne
     @JoinColumn(name = "board_id", nullable = false)
     private Board board;

--- a/src/main/java/yerong/wedle/post/domain/Post.java
+++ b/src/main/java/yerong/wedle/post/domain/Post.java
@@ -72,14 +72,6 @@ public class Post extends BaseTimeEntity {
         this.content = content;
     }
 
-    public void increaseLike() {
-        this.likeCount++;
-    }
-
-    public void decreaseLike() {
-        this.likeCount--;
-    }
-
     public void setHotBoardTime() {
         this.hotBoardTime = LocalDateTime.now();
     }

--- a/src/main/java/yerong/wedle/post/repository/PostRepository.java
+++ b/src/main/java/yerong/wedle/post/repository/PostRepository.java
@@ -1,7 +1,12 @@
 package yerong.wedle.post.repository;
 
+import jakarta.persistence.LockModeType;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import yerong.wedle.board.domain.Board;
 import yerong.wedle.community.domain.Community;
 import yerong.wedle.post.domain.Post;
@@ -10,4 +15,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findAllByBoard_CommunityAndIsHotBoardTrueOrderByHotBoardTimeDesc(Community community);
 
     List<Post> findAllByBoardOrderByCreatedAtDesc(Board board);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select p from Post p where p.id = :id")
+    Optional<Post> findByIdWithPessimisticLock(@Param("id") Long id);
 }


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/post-like` -> `develop`

### 변경 사항
- PostRepository: findByIdWithPessimisticLock 메서드 추가 (@Lock(LockModeType.PESSIMISTIC_WRITE) 적용)
- PostService: 좋아요 추가 로직에 동시성 제어 도입
- PostService: 좋아요 수 기준 변경 (postLikeRepository.countByPostId)
- 불필요한 likeCount 필드 증가 로직 제거

### 추가 설명
- 다수 사용자의 동시에 좋아요 클릭 시 HOT 게시판 진입 조건이 무시되는 문제를 해결하기 위해 Pessimistic Lock을 적용했습니다.
- 좋아요 수는 이제 Post 엔티티 내 필드가 아닌, PostLike 테이블 카운트 기반으로 처리되며, 모든 관련 작업은 트랜잭션 내에서 일괄 처리됩니다.

